### PR TITLE
Jmt key enum support

### DIFF
--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -499,7 +499,7 @@ impl fmt::Debug for DefaultHasher {
         write!(f, "DefaultHasher: state = Sha3")
     }
 }
-
+#[macro_export]
 macro_rules! define_hasher {
     (
         $(#[$attr:meta])*

--- a/src/mock_tree_store.rs
+++ b/src/mock_tree_store.rs
@@ -69,7 +69,7 @@ where
     V: crate::TestValue + Send + Sync,
 {
     fn write_node_batch<'future, 'a: 'future, 'n: 'future>(
-        &'a self,
+        &'a mut self,
         node_batch: &'n NodeBatch<V>,
     ) -> BoxFuture<'future, Result<()>> {
         Box::pin(async move {


### PR DESCRIPTION
Exposes the `define_hasher` macro and fixes the method signature of `write_node_batch`