### PR TITLE
Change DefaultHasher implementation to use Sha256 and repair/refactor any broken tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde-name = "0.2"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 bcs = "0.1.2"
 futures = "0.3"
+sha2 = "0.9.3"
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1079,6 +1079,7 @@ impl NibbleExt for HashValue {
 
 #[cfg(test)]
 mod test {
+
     use super::NibbleExt;
     use crate::hash::{HashValue, TestOnlyHash};
     use crate::types::nibble::Nibble;
@@ -1088,25 +1089,25 @@ mod test {
         {
             let hash1 = b"hello".test_only_hash();
             let hash2 = b"HELLO".test_only_hash();
-            assert_eq!(hash1[0], 0b0011_0011);
-            assert_eq!(hash2[0], 0b1011_1000);
+            assert_eq!(hash1[0], 0b0010_1100);
+            assert_eq!(hash2[0], 0b0011_0111);
             assert_eq!(hash1.common_prefix_nibbles_len(hash2), 0);
         }
         {
             let hash1 = b"hello".test_only_hash();
             let hash2 = b"world".test_only_hash();
-            assert_eq!(hash1[0], 0b0011_0011);
-            assert_eq!(hash2[0], 0b0100_0010);
+            assert_eq!(hash1[0], 0b0010_1100);
+            assert_eq!(hash2[0], 0b0100_1000);
             assert_eq!(hash1.common_prefix_nibbles_len(hash2), 0);
         }
         {
             let hash1 = b"hello".test_only_hash();
             let hash2 = b"100011001000".test_only_hash();
-            assert_eq!(hash1[0], 0b0011_0011);
-            assert_eq!(hash2[0], 0b0011_0011);
-            assert_eq!(hash1[1], 0b0011_1000);
-            assert_eq!(hash2[1], 0b0010_0010);
-            assert_eq!(hash1.common_prefix_nibbles_len(hash2), 2);
+            assert_eq!(hash1[0], 0b0010_1100);
+            assert_eq!(hash2[0], 0b0001_0111);
+            assert_eq!(hash1[1], 0b1111_0010);
+            assert_eq!(hash2[1], 0b1011_0011);
+            assert_eq!(hash1.common_prefix_nibbles_len(hash2), 0);
         }
         {
             let hash1 = b"hello".test_only_hash();
@@ -1121,11 +1122,12 @@ mod test {
     #[test]
     fn test_get_nibble() {
         let hash = b"hello".test_only_hash();
-        assert_eq!(hash.get_nibble(0), Nibble::from(3));
-        assert_eq!(hash.get_nibble(1), Nibble::from(3));
-        assert_eq!(hash.get_nibble(2), Nibble::from(3));
-        assert_eq!(hash.get_nibble(3), Nibble::from(8));
-        assert_eq!(hash.get_nibble(62), Nibble::from(9));
-        assert_eq!(hash.get_nibble(63), Nibble::from(2));
+
+        assert_eq!(hash.get_nibble(0), Nibble::from(2));
+        assert_eq!(hash.get_nibble(1), Nibble::from(12));
+        assert_eq!(hash.get_nibble(2), Nibble::from(15));
+        assert_eq!(hash.get_nibble(3), Nibble::from(2));
+        assert_eq!(hash.get_nibble(62), Nibble::from(2));
+        assert_eq!(hash.get_nibble(63), Nibble::from(4));
     }
 }

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -37,7 +37,7 @@ impl crate::CryptoHash for ValueBlob {
     type Hasher = crate::hash::TestOnlyHasher;
 
     fn hash(&self) -> HashValue {
-        HashValue::sha3_256_of(self.0.as_slice())
+        HashValue::sha256_of(self.0.as_slice())
     }
 }
 


### PR DESCRIPTION
Swap out all the Sha3 hashers in the JMT for Sha2 hashers, for faster hashing & wider support