### PR TITLE
Export merkle proof types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ use types::nibble::ROOT_NIBBLE_HEIGHT;
 
 pub use iterator::JellyfishMerkleIterator;
 pub use tree::JellyfishMerkleTree;
+pub use types::proof;
 pub use types::Version;
 
 /// Contains types used to bridge a [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -1,9 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod definition;
+//! Merkle proof types.
+
+pub(crate) mod definition;
 #[cfg(any(test, feature = "fuzzing"))]
-pub mod proptest_proof;
+pub(crate) mod proptest_proof;
 
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -12,7 +14,7 @@ use serde::{Deserialize, Serialize};
 pub use self::definition::{SparseMerkleProof, SparseMerkleRangeProof};
 use crate::{KeyHash, ValueHash};
 
-pub struct SparseMerkleInternalNode {
+pub(crate) struct SparseMerkleInternalNode {
     left_child: [u8; 32],
     right_child: [u8; 32],
 }
@@ -51,11 +53,11 @@ impl SparseMerkleLeafNode {
         }
     }
 
-    pub fn key_hash(&self) -> KeyHash {
+    pub(crate) fn key_hash(&self) -> KeyHash {
         self.key_hash
     }
 
-    pub fn hash(&self) -> [u8; 32] {
+    pub(crate) fn hash(&self) -> [u8; 32] {
         use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
         hasher.update(b"JMT::LeafNode");

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -31,7 +31,7 @@ pub struct SparseMerkleProof {
 
 impl SparseMerkleProof {
     /// Constructs a new `SparseMerkleProof` using leaf and a list of siblings.
-    pub fn new(leaf: Option<SparseMerkleLeafNode>, siblings: Vec<[u8; 32]>) -> Self {
+    pub(crate) fn new(leaf: Option<SparseMerkleLeafNode>, siblings: Vec<[u8; 32]>) -> Self {
         SparseMerkleProof { leaf, siblings }
     }
 
@@ -190,7 +190,7 @@ pub struct SparseMerkleRangeProof {
 
 impl SparseMerkleRangeProof {
     /// Constructs a new `SparseMerkleRangeProof`.
-    pub fn new(right_siblings: Vec<[u8; 32]>) -> Self {
+    pub(crate) fn new(right_siblings: Vec<[u8; 32]>) -> Self {
         Self { right_siblings }
     }
 


### PR DESCRIPTION
We didn't include these when reorganizing the crate API.