### PR TITLE
Remove prefixes for KeyHash and ValueHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ edition = "2018"
 default = ["ics23"]
 
 [dependencies]
-ics23 = { git = "https://github.com/penumbra-zone/ics23" , optional = true }
-
+ics23 = { version = "0.7" , optional = true }
 anyhow = "1.0.38"
 async-recursion = "1"
 byteorder = "1.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,11 @@ pub mod mock;
 pub mod restore;
 
 use bytes32ext::Bytes32Ext;
-use types::nibble::ROOT_NIBBLE_HEIGHT;
-
+#[cfg(feature = "ics23")]
+pub use ics23_impl::ics23_spec;
 pub use iterator::JellyfishMerkleIterator;
 pub use tree::JellyfishMerkleTree;
+use types::nibble::ROOT_NIBBLE_HEIGHT;
 pub use types::proof;
 pub use types::Version;
 
@@ -151,7 +152,6 @@ impl<V: AsRef<[u8]>> From<V> for ValueHash {
     fn from(value: V) -> Self {
         use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
-        hasher.update(b"JMT::Value");
         hasher.update(value.as_ref());
         Self(*hasher.finalize().as_ref())
     }
@@ -161,7 +161,6 @@ impl<K: AsRef<[u8]>> From<K> for KeyHash {
     fn from(key: K) -> Self {
         use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
-        hasher.update(b"JMT::Key");
         hasher.update(key.as_ref());
         Self(*hasher.finalize().as_ref())
     }


### PR DESCRIPTION
Couple tests failing here, pending the corresponding `ics23` updates