### PR TITLE
Add tracing output to the KeyHash's From impl.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ sha2 = "0.10"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
 async-recursion = "1"
+hex = "0.4"
+tracing = "0.1"
 
 [dev-dependencies]
 rand = { version = "0.8.3" }


### PR DESCRIPTION
This is useful because it allows the key bytes to be crossreferenced with the
key hash that appears in future tracing output.