### PR TITLE
Lift the WriteOverlay::PRE_GENESIS_VERSION associated constant into its own impl block.

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -21,14 +21,16 @@ pub struct WriteOverlay<R> {
     version: Version,
 }
 
+impl<R> WriteOverlay<R> {
+    /// Use this [`Version`] with [`Self::new`] to specify that the writes
+    /// should be committed with version `0`.
+    pub const PRE_GENESIS_VERSION: Version = u64::MAX;
+}
+
 impl<R> WriteOverlay<R>
 where
     R: TreeReader + Sync,
 {
-    /// Use this [`Version`] with [`Self::new`] to specify that the writes
-    /// should be committed with version `0`.
-    pub const PRE_GENESIS_VERSION: Version = u64::MAX;
-
     /// Constructs a new [`WriteOverlay`] with the given `reader` and `version`.
     ///
     /// All reads performed with `get` will use `version` when querying the


### PR DESCRIPTION


The current code makes it difficult to use, because the associated constant is
only defined for `WriteOverlay<R>` where `R` satisfies the trait bounds.
Instead, lifting it into its own impl allows it to be used for any `R`, which
is better, because the value doesn't depend on `R`.