### PR TITLE
deps: rely on upstream `ics23@=0.8.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 default = ["ics23"]
 
 [dependencies]
-ics23 = { git = "https://github.com/penumbra-zone/ics23", branch = "penumbra-034", optional = true }
+ics23 = { version = "=0.8.1", optional = true }
 anyhow = "1.0.38"
 byteorder = "1.4.3"
 itertools = { version = "0.10.0", default-features = false }


### PR DESCRIPTION
Part of https://github.com/penumbra-zone/penumbra/pull/1650

Will merge this once the parent PR is ready for inclusion in penumbra@main