### PR TITLE
Fix CI: Use ICS 23 fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ edition = "2021"
 default = ["ics23"]
 
 [dependencies]
-ics23 = { git = "https://github.com/heliaxdev/ics23", branch = "yuji/compare_hashed_key", optional = true }
+# FIXME: Do not merge into main with a git dependency here. Wait for https://github.com/cosmos/ics23/pull/88
+ics23 = { git = "https://github.com/preston-evans98/ics23", branch = "yuji/compare_hashed_key", optional = true }
 anyhow = "1.0.38"
 byteorder = "1.4.3"
 itertools = { version = "0.10.0", default-features = false }

--- a/src/tree/ics23_impl.rs
+++ b/src/tree/ics23_impl.rs
@@ -257,15 +257,9 @@ mod tests {
 
             let mut kvs = Vec::new();
 
-            // Ensure that the tree contains at least one key-value pair
             kvs.push((KeyHash::from(b"key"), Some(b"value1".to_vec())));
             db.put_key_preimage(&b"key".to_vec());
-
             for key_preimage in keys {
-                // Since we hardcode the check for key, ensure that it's not inserted randomly by proptest
-                if key_preimage == b"notexist" {
-                    continue
-                }
                 let key_hash = KeyHash::from(&key_preimage);
                 let value = vec![0u8; 32];
                 kvs.push((key_hash, Some(value)));
@@ -278,6 +272,7 @@ mod tests {
             let commitment_proof = tree
                 .get_with_ics23_proof(b"notexist".to_vec(), 0)
                 .unwrap();
+
 
             let key_hash = b"notexist".as_slice().into();
             let proof_or_exclusion = tree.get_with_exclusion_proof(key_hash, 0).unwrap();
@@ -333,8 +328,14 @@ mod tests {
                         },
                     }
                 }
-
             }
+
+            assert!(!ics23::verify_non_membership::<HostFunctionsManager>(
+                &commitment_proof,
+                &ics23_spec(),
+                &new_root_hash.0.to_vec(),
+                b"key",
+            ));
         }
     }
 


### PR DESCRIPTION
The previous commit removed a useful test for forged non-exclusion proofs. Revert it, and fix the underlying cause of the CI failure by relying on a forked version of ICS 23. 