### PR TITLE
Separate values from leaf nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ edition = "2021"
 default = ["ics23"]
 
 [dependencies]
-ics23 = { git = "https://github.com/heliaxdev/ics23", branch = "yuji/compare_hashed_key", optional = true }
+# FIXME: Do not merge into main with a git dependency here. Wait for https://github.com/cosmos/ics23/pull/88
+ics23 = { git = "https://github.com/preston-evans98/ics23", branch = "yuji/compare_hashed_key", optional = true }
 anyhow = "1.0.38"
 byteorder = "1.4.3"
 itertools = { version = "0.10.0", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,8 @@ pub mod storage {
     pub use reader::HasPreimage;
     pub use reader::TreeReader;
     pub use writer::{
-        NodeBatch, NodeStats, StaleNodeIndex, StaleNodeIndexBatch, TreeUpdateBatch, TreeWriter,
+        NodeStats, StaleNodeIndex, StaleNodeIndexBatch, TreeChangeBatch, TreeUpdateBatch,
+        TreeWriter,
     };
 
     use super::*;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -3,13 +3,15 @@
 
 //! A mock, in-memory tree store useful for testing.
 
-use std::collections::{hash_map::Entry, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 
 use crate::{
-    node_type::{LeafNode, Node, NodeKey},
-    storage::{HasPreimage, NodeBatch, StaleNodeIndex, TreeReader, TreeUpdateBatch, TreeWriter},
+    node_type::{AugmentedNode, LeafNode, Node, NodeKey},
+    storage::{
+        HasPreimage, StaleNodeIndex, TreeChangeBatch, TreeReader, TreeUpdateBatch, TreeWriter,
+    },
     types::Version,
     KeyHash,
 };
@@ -22,19 +24,24 @@ use rwlock::RwLock;
 /// The tree store is internally represented with a `HashMap`.  This structure
 /// is exposed for use only by downstream crates' tests, and it should obviously
 /// not be used in production.
+#[derive(Debug)]
 pub struct MockTreeStore {
-    data: RwLock<(
-        HashMap<NodeKey, Node>,
-        BTreeSet<StaleNodeIndex>,
-        HashMap<KeyHash, Vec<u8>>,
-    )>,
+    data: RwLock<MockTreeStoreInner>,
     allow_overwrite: bool,
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct MockTreeStoreInner {
+    pub nodes: HashMap<NodeKey, Node>,
+    pub values: BTreeMap<Version, HashMap<KeyHash, Option<Vec<u8>>>>,
+    pub stale_nodes: BTreeSet<StaleNodeIndex>,
+    pub preimages: HashMap<KeyHash, Vec<u8>>,
 }
 
 impl Default for MockTreeStore {
     fn default() -> Self {
         Self {
-            data: RwLock::new((HashMap::new(), BTreeSet::new(), HashMap::new())),
+            data: RwLock::new(Default::default()),
             allow_overwrite: false,
         }
     }
@@ -42,14 +49,14 @@ impl Default for MockTreeStore {
 
 impl TreeReader for MockTreeStore {
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
-        Ok(self.data.read().0.get(node_key).cloned())
+        Ok(self.data.read().nodes.get(node_key).cloned())
     }
 
     fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>> {
         let locked = self.data.read();
         let mut node_key_and_node: Option<(NodeKey, LeafNode)> = None;
 
-        for (key, value) in locked.0.iter() {
+        for (key, value) in locked.nodes.iter() {
             if let Node::Leaf(leaf_node) = value {
                 if node_key_and_node.is_none()
                     || leaf_node.key_hash() > node_key_and_node.as_ref().unwrap().1.key_hash()
@@ -61,24 +68,67 @@ impl TreeReader for MockTreeStore {
 
         Ok(node_key_and_node)
     }
+
+    fn get_value_option(
+        &self,
+        value_id: &crate::types::value_identifier::ValueIdentifier,
+    ) -> Result<Option<crate::OwnedValue>> {
+        for (_, values) in self.data.read().values.range(0..=value_id.version()).rev() {
+            if let Some(v) = values.get(&value_id.key_hash()) {
+                return Ok(v.clone());
+            }
+        }
+        Ok(None)
+    }
 }
 
 impl HasPreimage for MockTreeStore {
     fn preimage(&self, key_hash: KeyHash) -> Result<Option<Vec<u8>>> {
-        Ok(self.data.read().2.get(&key_hash).cloned())
+        Ok(self.data.read().preimages.get(&key_hash).cloned())
     }
 }
 
 impl TreeWriter for MockTreeStore {
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
+    fn write_node_batch(&self, node_batch: &TreeChangeBatch) -> Result<()> {
         let mut locked = self.data.write();
-        for (node_key, node) in node_batch.clone() {
-            let replaced = locked.0.insert(node_key, node);
+        for (node_key, node) in node_batch.nodes().clone() {
+            let node_to_insert = if let AugmentedNode::Leaf(augmented_leaf) = node {
+                let (leaf, value) = augmented_leaf.split();
+                put_value(
+                    &mut locked.values,
+                    node_key.version(),
+                    leaf.key_hash(),
+                    Some(value),
+                );
+                Node::Leaf(leaf)
+            } else {
+                node.into()
+            };
+
+            let replaced = locked.nodes.insert(node_key, node_to_insert);
             if !self.allow_overwrite {
                 assert_eq!(replaced, None);
             }
         }
+        for idx in node_batch.deleted_values() {
+            put_value(&mut locked.values, idx.version(), idx.key_hash(), None)
+        }
         Ok(())
+    }
+}
+pub fn put_value(
+    values: &mut BTreeMap<Version, HashMap<KeyHash, Option<Vec<u8>>>>,
+    version: u64,
+    key_hash: KeyHash,
+    value: Option<Vec<u8>>,
+) {
+    match values.entry(version) {
+        std::collections::btree_map::Entry::Vacant(v) => {
+            v.insert([(key_hash, value)].into_iter().collect());
+        }
+        std::collections::btree_map::Entry::Occupied(mut o) => {
+            o.get_mut().insert(key_hash, value);
+        }
     }
 }
 
@@ -90,33 +140,30 @@ impl MockTreeStore {
         }
     }
 
-    pub fn put_node(&self, node_key: NodeKey, node: Node) -> Result<()> {
-        match self.data.write().0.entry(node_key) {
-            Entry::Occupied(o) => bail!("Key {:?} exists.", o.key()),
-            Entry::Vacant(v) => {
-                v.insert(node);
-            }
-        }
-        Ok(())
+    pub fn put_node(&self, node_key: NodeKey, node: AugmentedNode) -> Result<()> {
+        self.write_node_batch(&TreeChangeBatch {
+            insertions: vec![(node_key, node)].into_iter().collect(),
+            deleted_values: vec![],
+        })
     }
 
     pub fn put_key_preimage(&self, preimage: &Vec<u8>) {
         let key_hash: KeyHash = preimage.into();
-        self.data.write().2.insert(key_hash, preimage.clone());
+        self.data
+            .write()
+            .preimages
+            .insert(key_hash, preimage.clone());
     }
 
     fn put_stale_node_index(&self, index: StaleNodeIndex) -> Result<()> {
-        let is_new_entry = self.data.write().1.insert(index);
+        let is_new_entry = self.data.write().stale_nodes.insert(index);
         ensure!(is_new_entry, "Duplicated retire log.");
         Ok(())
     }
 
     pub fn write_tree_update_batch(&self, batch: TreeUpdateBatch) -> Result<()> {
-        batch
-            .node_batch
-            .into_iter()
-            .map(|(k, v)| self.put_node(k, v))
-            .collect::<Result<Vec<_>>>()?;
+        self.write_node_batch(&batch.node_batch)?;
+
         batch
             .stale_node_index_batch
             .into_iter()
@@ -131,22 +178,25 @@ impl MockTreeStore {
         // Only records retired before or at `least_readable_version` can be purged in order
         // to keep that version still readable.
         let to_prune = wlocked
-            .1
+            .stale_nodes
             .iter()
             .take_while(|log| log.stale_since_version <= least_readable_version)
             .cloned()
             .collect::<Vec<_>>();
 
         for log in to_prune {
-            let removed = wlocked.0.remove(&log.node_key).is_some();
-            ensure!(removed, "Stale node index refers to non-existent node.");
-            wlocked.1.remove(&log);
+            let removed_node = wlocked.nodes.remove(&log.node_key);
+            ensure!(
+                removed_node.is_some(),
+                "Stale node index refers to non-existent node."
+            );
+            wlocked.stale_nodes.remove(&log);
         }
 
         Ok(())
     }
 
     pub fn num_nodes(&self) -> usize {
-        self.data.read().0.len()
+        self.data.read().nodes.len()
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,7 +1,8 @@
 use anyhow::{format_err, Result};
 
-use crate::node_type::{LeafNode, Node, NodeKey};
-use crate::KeyHash;
+use crate::node_type::{AugmentedLeafNode, AugmentedNode, LeafNode, Node, NodeKey};
+use crate::types::value_identifier::ValueIdentifier;
+use crate::{KeyHash, OwnedValue};
 
 /// Defines the interface between a
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
@@ -15,6 +16,52 @@ pub trait TreeReader {
 
     /// Gets node given a node key. Returns `None` if the node does not exist.
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>>;
+
+    /// Gets a value by identifier, returning the newest value whose version is *less than or
+    /// equal to* the specified version. Returns an error if the value does not exist.
+    fn get_value(&self, value_id: &ValueIdentifier) -> Result<OwnedValue> {
+        self.get_value_option(value_id)?
+            .ok_or_else(|| format_err!("Missing value with id {value_id:?}."))
+    }
+
+    /// Gets a value by identifier, returning the newest value whose version is *less than or
+    /// equal to* the specified version.  Returns None if the value does not exist.
+    fn get_value_option(&self, value_id: &ValueIdentifier) -> Result<Option<OwnedValue>>;
+
+    /// Gets the latest version of a value given the key hash. Returns an error if the value does not exist.
+    fn get_latest_value(&self, key_hash: KeyHash) -> Result<OwnedValue> {
+        self.get_latest_value_option(key_hash)?
+            .ok_or_else(|| format_err!("Missing value with key_hash {key_hash:?}."))
+    }
+
+    /// Gets the latest version of a value given the key hash. Returns None if the value does not exist.
+    fn get_latest_value_option(&self, key_hash: KeyHash) -> Result<Option<OwnedValue>> {
+        self.get_value_option(&ValueIdentifier::new(u64::MAX, key_hash))
+    }
+
+    /// Gets an [`AugmentedNode`] given a [`NodeKey`]. Returns an error if the node does not exist
+    fn get_augmented_node(&self, node_key: &NodeKey) -> Result<AugmentedNode> {
+        self.get_augmented_node_option(node_key)?
+            .ok_or_else(|| format_err!("Missing augmented node with key {:?}.", node_key))
+    }
+
+    /// Gets an [`AugmentedNode`] given a [`NodeKey`]. Returns `None` if the node does not exist.
+    fn get_augmented_node_option(&self, node_key: &NodeKey) -> Result<Option<AugmentedNode>> {
+        if let Some(node) = self.get_node_option(node_key)? {
+            return match node {
+                Node::Null => Ok(Some(AugmentedNode::Null)),
+                Node::Internal(internal) => Ok(Some(internal.into())),
+                Node::Leaf(leaf) => {
+                    let value =
+                        self.get_value(&ValueIdentifier::new(node_key.version(), leaf.key_hash()))?;
+                    Ok(Some(AugmentedNode::Leaf(AugmentedLeafNode::from_parts(
+                        leaf, value,
+                    ))))
+                }
+            };
+        };
+        Ok(None)
+    }
 
     /// Gets the rightmost leaf. Note that this assumes we are in the process of restoring the tree
     /// and all nodes are at the same version.

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -601,7 +601,7 @@ fn verify_range_proof(
     // that would cause `X` to end up in the above position.
     let mut btree1 = BTreeMap::new();
     for (key, value) in &btree {
-        let leaf = LeafNode::new(*key, value.clone());
+        let leaf = LeafNode::new(*key, (&value[..]).into());
         btree1.insert(*key, leaf.hash());
     }
     // Using the above example, `last_proven_key` is `e`. We look at the path from root to `e`.

--- a/src/tests/node_type.rs
+++ b/src/tests/node_type.rs
@@ -8,8 +8,8 @@ use rand::rngs::OsRng;
 
 use crate::{
     node_type::{
-        deserialize_u64_varint, serialize_u64_varint, Child, Children, InternalNode, Node,
-        NodeDecodeError, NodeKey, NodeType,
+        deserialize_u64_varint, serialize_u64_varint, AugmentedNode, Child, Children, InternalNode,
+        Node, NodeDecodeError, NodeKey, NodeType,
     },
     types::{
         nibble::{nibble_path::NibblePath, Nibble},
@@ -135,7 +135,7 @@ fn test_leaf_hash() {
         let blob = vec![0x02];
         let value_hash: ValueHash = blob.as_slice().into();
         let hash = hash_leaf(address, value_hash);
-        let leaf_node = Node::new_leaf(address, blob);
+        let leaf_node = AugmentedNode::new_leaf(address, blob);
         assert_eq!(leaf_node.hash(), hash);
     }
 }

--- a/src/tests/tree_cache.rs
+++ b/src/tests/tree_cache.rs
@@ -5,17 +5,17 @@ use rand::{rngs::OsRng, Rng};
 
 use crate::{
     mock::MockTreeStore,
-    node_type::{Node, NodeKey},
+    node_type::{AugmentedNode, NodeKey},
     tree_cache::TreeCache,
     types::{nibble::nibble_path::NibblePath, Version, PRE_GENESIS_VERSION},
     KeyHash,
 };
 
-fn random_leaf_with_key(next_version: Version) -> (Node, NodeKey) {
+fn random_leaf_with_key(next_version: Version) -> (AugmentedNode, NodeKey) {
     let key: [u8; 32] = OsRng.gen();
     let value: [u8; 32] = OsRng.gen();
     let key_hash: KeyHash = key.as_ref().into();
-    let node = Node::new_leaf(key_hash, value.to_vec());
+    let node = AugmentedNode::new_leaf(key_hash, value.to_vec());
     let node_key = NodeKey::new(next_version, NibblePath::new(key_hash.0.to_vec()));
     (node, node_key)
 }
@@ -80,6 +80,6 @@ fn test_freeze_with_delete() {
     cache.delete_node(&node1_key, true /* is_leaf */);
     cache.freeze().unwrap();
     let (_, update_batch) = cache.into();
-    assert_eq!(update_batch.node_batch.len(), 3);
+    assert_eq!(update_batch.node_batch.nodes().len(), 3);
     assert_eq!(update_batch.stale_node_index_batch.len(), 1);
 }

--- a/src/tree/ics23_impl.rs
+++ b/src/tree/ics23_impl.rs
@@ -257,15 +257,9 @@ mod tests {
 
             let mut kvs = Vec::new();
 
-            // Ensure that the tree contains at least one key-value pair
             kvs.push((KeyHash::from(b"key"), Some(b"value1".to_vec())));
             db.put_key_preimage(&b"key".to_vec());
-
             for key_preimage in keys {
-                // Since we hardcode the check for key, ensure that it's not inserted randomly by proptest
-                if key_preimage == b"notexist" {
-                    continue
-                }
                 let key_hash = KeyHash::from(&key_preimage);
                 let value = vec![0u8; 32];
                 kvs.push((key_hash, Some(value)));
@@ -278,6 +272,7 @@ mod tests {
             let commitment_proof = tree
                 .get_with_ics23_proof(b"notexist".to_vec(), 0)
                 .unwrap();
+
 
             let key_hash = b"notexist".as_slice().into();
             let proof_or_exclusion = tree.get_with_exclusion_proof(key_hash, 0).unwrap();
@@ -333,8 +328,14 @@ mod tests {
                         },
                     }
                 }
-
             }
+
+            assert!(!ics23::verify_non_membership::<HostFunctionsManager>(
+                &commitment_proof,
+                &ics23_spec(),
+                &new_root_hash.0.to_vec(),
+                b"key",
+            ));
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@
 
 pub mod nibble;
 pub mod proof;
+pub mod value_identifier;
 
 /// Specifies a particular version of the [`JellyfishMerkleTree`](crate::JellyfishMerkleTree) state.
 pub type Version = u64; // Height - also used for MVCC in StateDB

--- a/src/types/value_identifier.rs
+++ b/src/types/value_identifier.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{KeyHash, Version};
+
+/// Uniquely identifies a value stored in the [`JellyfishMerkleTree`](crate::JellyfishMerkleTree).
+/// Enables efficient lookups on values without traversing the tree.
+// TODO: REmove ordering
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ValueIdentifier {
+    version: Version,
+    key_hash: KeyHash,
+}
+
+impl ValueIdentifier {
+    pub fn new(version: u64, key_hash: KeyHash) -> Self {
+        Self { version, key_hash }
+    }
+
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    pub fn key_hash(&self) -> KeyHash {
+        self.key_hash
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -5,20 +5,73 @@ use anyhow::Result;
 use proptest_derive::Arbitrary;
 
 use crate::{
-    node_type::{Node, NodeKey},
-    types::Version,
+    node_type::{AugmentedNode, NodeKey},
+    types::{value_identifier::ValueIdentifier, Version},
 };
 
 /// Defines the interface used to write a batch of updates from a
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
 /// to the underlying storage holding nodes.
 pub trait TreeWriter {
-    /// Writes a node batch into storage.
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()>;
+    /// Writes a node batch into storage. Note: all deleted values must be processed by the
+    /// underlying data store, or the JMT may return incorrect results during `get` queries.
+    fn write_node_batch(&self, node_batch: &TreeChangeBatch) -> Result<()>;
 }
 
-/// Node batch that will be written into db atomically with other batches.
-pub type NodeBatch = BTreeMap<NodeKey, Node>;
+/// A batch of changes to the tree that will be written into db atomically with other batches.
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct TreeChangeBatch {
+    pub insertions: BTreeMap<NodeKey, AugmentedNode>,
+    pub deleted_values: Vec<ValueIdentifier>,
+}
+
+impl TreeChangeBatch {
+    /// Reset a NodeBatch to its empty state
+    pub fn clear(&mut self) {
+        self.insertions.clear();
+        self.deleted_values.clear()
+    }
+
+    /// Get a node by key
+    pub fn get_node(&self, node_key: &NodeKey) -> Option<&AugmentedNode> {
+        self.insertions.get(node_key)
+    }
+
+    /// Returns a reference to the current set of nodes
+    pub fn nodes(&self) -> &BTreeMap<NodeKey, AugmentedNode> {
+        &self.insertions
+    }
+
+    /// Insert a node into the batch
+    pub fn insert_node(&mut self, node_key: NodeKey, node: AugmentedNode) -> Option<AugmentedNode> {
+        self.insertions.insert(node_key, node)
+    }
+
+    /// Returns a reference to the current set of nodes
+    pub fn deleted_values(&self) -> &Vec<ValueIdentifier> {
+        &self.deleted_values
+    }
+
+    /// Extend a node batch
+    pub fn extend(
+        &mut self,
+        nodes: impl IntoIterator<Item = (NodeKey, AugmentedNode)>,
+        deleted_values: impl IntoIterator<Item = ValueIdentifier>,
+    ) {
+        self.insertions.extend(nodes);
+        self.deleted_values.extend(deleted_values);
+    }
+
+    /// Merge two NodeBatches into a single one
+    pub fn merge(&mut self, rhs: Self) {
+        self.extend(rhs.insertions, rhs.deleted_values)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.insertions.is_empty() && self.deleted_values.is_empty()
+    }
+}
+
 /// [`StaleNodeIndex`](struct.StaleNodeIndex.html) batch that will be written into db atomically
 /// with other batches.
 pub type StaleNodeIndexBatch = BTreeSet<StaleNodeIndex>;
@@ -48,7 +101,7 @@ pub struct StaleNodeIndex {
 /// which is a vector of `hashed_account_address` and `new_value` pairs.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TreeUpdateBatch {
-    pub node_batch: NodeBatch,
+    pub node_batch: TreeChangeBatch,
     pub stale_node_index_batch: StaleNodeIndexBatch,
     pub node_stats: Vec<NodeStats>,
 }


### PR DESCRIPTION
This PR separates the `value` field from `LeafNode`, allowing values to be handled separately in the underlying data store. This allows very efficent `get` operations, since the tree no longer needs to be traversed in order to find the value of a given key. The tree is still traversed if a proof is requested.

This PR is marked as draft since it is based on the `exclusion-proofs` branch instead of `main`. Once https://github.com/cosmos/ics23/pull/88 lands and we merge exclusion-proofs, I'll rebase on top of main.