### PR TITLE
Separate LeafNodes from values

### DIFF
--- a/src/node_type.rs
+++ b/src/node_type.rs
@@ -800,29 +800,20 @@ pub struct LeafNode {
     key_hash: KeyHash,
     /// The hash of the value for this entry.
     value_hash: ValueHash,
-    /// The value associated with the key.
-    value: Vec<u8>,
 }
 
 impl LeafNode {
     /// Creates a new leaf node.
-    pub fn new(key_hash: KeyHash, value: Vec<u8>) -> Self {
-        let value_hash = value.as_slice().into();
+    pub fn new(key_hash: KeyHash, value_hash: ValueHash) -> Self {
         Self {
             key_hash,
             value_hash,
-            value,
         }
     }
 
     /// Gets the key hash.
     pub fn key_hash(&self) -> KeyHash {
         self.key_hash
-    }
-
-    /// Gets the associated value itself.
-    pub fn value(&self) -> &[u8] {
-        self.value.as_ref()
     }
 
     /// Gets the associated value hash.
@@ -892,10 +883,9 @@ impl Node {
     }
 
     /// Creates the [`Leaf`](Node::Leaf) variant.
-    pub(crate) fn new_leaf(key_hash: KeyHash, value: Vec<u8>) -> Self {
-        Node::Leaf(LeafNode::new(key_hash, value))
+    pub(crate) fn new_leaf(key_hash: KeyHash, value_hash: ValueHash) -> Self {
+        Node::Leaf(LeafNode::new(key_hash, value_hash))
     }
-
     /// Returns `true` if the node is a leaf node.
     pub(crate) fn is_leaf(&self) -> bool {
         matches!(self, Node::Leaf(_))

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,7 @@
 use anyhow::{format_err, Result};
 
 use crate::node_type::{LeafNode, Node, NodeKey};
+use crate::{KeyHash, OwnedValue, Version};
 
 /// Defines the interface between a
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
@@ -14,6 +15,25 @@ pub trait TreeReader {
 
     /// Gets node given a node key. Returns `None` if the node does not exist.
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>>;
+
+    /// Gets a value by identifier, returning the newest value whose version is *less than or
+    /// equal to* the specified version. Returns an error if the value does not exist.
+    fn get_value(&self, max_version: Version, key_hash: KeyHash) -> Result<OwnedValue> {
+        self.get_value_option(max_version, key_hash)?
+            .ok_or_else(|| {
+                format_err!(
+                    "Missing value with max_version {max_version:} and key hash {key_hash:?}."
+                )
+            })
+    }
+
+    /// Gets a value by identifier, returning the newest value whose version is *less than or
+    /// equal to* the specified version.  Returns None if the value does not exist.
+    fn get_value_option(
+        &self,
+        max_version: Version,
+        key_hash: KeyHash,
+    ) -> Result<Option<OwnedValue>>;
 
     /// Gets the rightmost leaf. Note that this assumes we are in the process of restoring the tree
     /// and all nodes are at the same version.

--- a/src/tests/helper.rs
+++ b/src/tests/helper.rs
@@ -601,7 +601,7 @@ fn verify_range_proof(
     // that would cause `X` to end up in the above position.
     let mut btree1 = BTreeMap::new();
     for (key, value) in &btree {
-        let leaf = LeafNode::new(*key, value.clone());
+        let leaf = LeafNode::new(*key, value.as_slice().into());
         btree1.insert(*key, leaf.hash());
     }
     // Using the above example, `last_proven_key` is `e`. We look at the path from root to `e`.

--- a/src/tests/node_type.rs
+++ b/src/tests/node_type.rs
@@ -49,9 +49,9 @@ fn test_encode_decode() {
     let internal_node_key = random_63nibbles_node_key();
 
     let leaf1_keys = gen_leaf_keys(0, internal_node_key.nibble_path(), Nibble::from(1));
-    let leaf1_node = Node::new_leaf(leaf1_keys.1, vec![0x00]);
+    let leaf1_node = Node::new_leaf(leaf1_keys.1, vec![0x00].into());
     let leaf2_keys = gen_leaf_keys(0, internal_node_key.nibble_path(), Nibble::from(2));
-    let leaf2_node = Node::new_leaf(leaf2_keys.1, vec![0x01]);
+    let leaf2_node = Node::new_leaf(leaf2_keys.1, vec![0x01].into());
 
     let mut children = Children::default();
     children.insert(
@@ -66,7 +66,7 @@ fn test_encode_decode() {
     let account_key = KeyHash(OsRng.gen());
     let nodes = vec![
         Node::new_internal(children),
-        Node::new_leaf(account_key, vec![0x02]),
+        Node::new_leaf(account_key, vec![0x02].into()),
     ];
     for n in &nodes {
         let v = n.encode().unwrap();
@@ -135,7 +135,7 @@ fn test_leaf_hash() {
         let blob = vec![0x02];
         let value_hash: ValueHash = blob.as_slice().into();
         let hash = hash_leaf(address, value_hash);
-        let leaf_node = Node::new_leaf(address, blob);
+        let leaf_node = Node::new_leaf(address, blob.into());
         assert_eq!(leaf_node.hash(), hash);
     }
 }

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -121,7 +121,7 @@ pub struct TreeCache<'a, R> {
     node_cache: HashMap<NodeKey, Node>,
 
     /// Values keyed by version and keyhash.
-    // TODO(@preston-evans98): Convert to a once we remove the non-batch APIs.
+    // TODO(@preston-evans98): Convert to a vector once we remove the non-batch APIs.
     // The Hashmap guarantees that if the same (version, key) pair is written several times, only the last
     // change is saved, which means that the TreeWriter can process node batches in parallel without racing.
     // The batch APIs already deduplicate operations on each key, so they don't need this HashMap.

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,5 +9,5 @@ pub mod proof;
 /// Specifies a particular version of the [`JellyfishMerkleTree`](crate::JellyfishMerkleTree) state.
 pub type Version = u64; // Height - also used for MVCC in StateDB
 
-// In StateDB, things readable by the genesis transaction are under this version.
+/// The version before the genesis state. This version should always be empty.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();

--- a/src/types/nibble.rs
+++ b/src/types/nibble.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::{Bytes32Ext, KeyHash, OwnedValue};
+use crate::{Bytes32Ext, KeyHash, ValueHash};
 
 /// The hardcoded maximum height of a state merkle tree in nibbles.
 pub const ROOT_NIBBLE_HEIGHT: usize = 32 * 2;
@@ -49,13 +49,13 @@ impl Nibble {
 /// An iterator that iterates the index range (inclusive) of each different nibble at given
 /// `nibble_idx` of all the keys in a sorted key-value pairs.
 pub(crate) struct NibbleRangeIterator<'a> {
-    sorted_kvs: &'a [(KeyHash, OwnedValue)],
+    sorted_kvs: &'a [(KeyHash, ValueHash)],
     nibble_idx: usize,
     pos: usize,
 }
 
 impl<'a> NibbleRangeIterator<'a> {
-    pub fn new(sorted_kvs: &'a [(KeyHash, OwnedValue)], nibble_idx: usize) -> Self {
+    pub fn new(sorted_kvs: &'a [(KeyHash, ValueHash)], nibble_idx: usize) -> Self {
         assert!(nibble_idx < ROOT_NIBBLE_HEIGHT);
         NibbleRangeIterator {
             sorted_kvs,


### PR DESCRIPTION
## Separate LeafNodes from values
    
This PR removes the `value` field from `LeafNode`, allowing values to be handled separately in the underlying data store. This allows very efficent `get` operations, since the tree no longer needs to be traversed in order to find the value of a given key. The tree is still traversed if a proof is requested.