### PR TITLE
Bug fix: incorrect field name in ics23_spec

### DIFF
--- a/src/tree/ics23_impl.rs
+++ b/src/tree/ics23_impl.rs
@@ -235,7 +235,7 @@ pub fn ics23_spec() -> ics23::ProofSpec {
         }),
         min_depth: 0,
         max_depth: 64,
-        prehash_compare_key: true,
+        prehash_key_before_comparison: true,
     }
 }
 


### PR DESCRIPTION
This PR updates one of the field names in the struct created by `ics23_spec()` from `prehash_compare_key` to `prehash_key_before_comparison`