### PR TITLE
Add missing serde derives

### DIFF
--- a/src/node_type.rs
+++ b/src/node_type.rs
@@ -757,7 +757,7 @@ impl From<LeafNode> for SparseMerkleLeafNode {
 }
 
 #[repr(u8)]
-#[derive(FromPrimitive, ToPrimitive, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[derive(FromPrimitive, ToPrimitive, BorshDeserialize, BorshSerialize)]
 enum NodeTag {
     Null = 0,
     Leaf = 1,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,8 +2,10 @@ use alloc::collections::{BTreeMap, BTreeSet};
 
 use alloc::vec::Vec;
 use anyhow::Result;
+use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     node_type::{Node, NodeKey},
@@ -20,7 +22,17 @@ pub trait TreeWriter {
 }
 
 /// Node batch that will be written into db atomically with other batches.
-#[derive(Debug, Clone, PartialEq, Default, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Default,
+    Eq,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+    Serialize,
+    Deserialize,
+)]
 pub struct NodeBatch {
     nodes: BTreeMap<NodeKey, Node>,
     values: BTreeMap<(Version, KeyHash), Option<OwnedValue>>,
@@ -82,7 +94,17 @@ impl NodeBatch {
 /// with other batches.
 pub type StaleNodeIndexBatch = BTreeSet<StaleNodeIndex>;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+    Serialize,
+    Deserialize,
+)]
 pub struct NodeStats {
     pub new_nodes: usize,
     pub new_leaves: usize,
@@ -91,9 +113,20 @@ pub struct NodeStats {
 }
 
 /// Indicates a node becomes stale since `stale_since_version`.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    BorshDeserialize,
+    BorshSerialize,
+)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-#[derive(borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct StaleNodeIndex {
     /// The version since when the node is overwritten and becomes stale.
     pub stale_since_version: Version,
@@ -106,7 +139,9 @@ pub struct StaleNodeIndex {
 /// [`StaleNodeIndexBatch`](type.StaleNodeIndexBatch.html) and some stats of nodes that represents
 /// the incremental updates of a tree and pruning indices after applying a write set,
 /// which is a vector of `hashed_account_address` and `new_value` pairs.
-#[derive(Clone, Debug, Default, Eq, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(
+    Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
+)]
 pub struct TreeUpdateBatch {
     pub node_batch: NodeBatch,
     pub stale_node_index_batch: StaleNodeIndexBatch,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -94,17 +94,7 @@ impl NodeBatch {
 /// with other batches.
 pub type StaleNodeIndexBatch = BTreeSet<StaleNodeIndex>;
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    Eq,
-    PartialEq,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-    Serialize,
-    Deserialize,
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct NodeStats {
     pub new_nodes: usize,
     pub new_leaves: usize,
@@ -113,19 +103,7 @@ pub struct NodeStats {
 }
 
 /// Indicates a node becomes stale since `stale_since_version`.
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    Deserialize,
-    BorshDeserialize,
-    BorshSerialize,
-)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, BorshDeserialize, BorshSerialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct StaleNodeIndex {
     /// The version since when the node is overwritten and becomes stale.
@@ -139,9 +117,7 @@ pub struct StaleNodeIndex {
 /// [`StaleNodeIndexBatch`](type.StaleNodeIndexBatch.html) and some stats of nodes that represents
 /// the incremental updates of a tree and pruning indices after applying a write set,
 /// which is a vector of `hashed_account_address` and `new_value` pairs.
-#[derive(
-    Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
 pub struct TreeUpdateBatch {
     pub node_batch: NodeBatch,
     pub stale_node_index_batch: StaleNodeIndexBatch,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -22,17 +22,7 @@ pub trait TreeWriter {
 }
 
 /// Node batch that will be written into db atomically with other batches.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Default,
-    Eq,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-    Serialize,
-    Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, Default, Eq, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct NodeBatch {
     nodes: BTreeMap<NodeKey, Node>,
     values: BTreeMap<(Version, KeyHash), Option<OwnedValue>>,


### PR DESCRIPTION
Jmt already derives serde for most types, but a few were missing. This PR adds derives on the missing types.