### PR TITLE
ci: emit proptest regressions on test failures

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -29,10 +29,10 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+      - name: cargo test
+        run: >-
+          cargo test --no-default-features
+          || find -type f -iname '*.proptest-regressions' -exec cat {} +
 
   test-default-features:
     name: Test Suite with Default Features
@@ -45,13 +45,10 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+      - name: cargo test
+        run: >-
+          cargo test
+          || find -type f -iname '*.proptest-regressions' -exec cat {} +
 
   test-all-features:
     name: Test Suite with All Features
@@ -64,10 +61,10 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+      - name: cargo test
+        run: >-
+          cargo test --all-features
+          || find -type f -iname '*.proptest-regressions' -exec cat {} +
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
After merge of https://github.com/penumbra-zone/jmt/pull/92, we observed a CI test failure on the `main` branch [0]. We couldn't reproduce locally, and a subsequent CI re-run passed [1], so we're chalking it up to non-determinism caused by our use of proptest. When proptest finds a failure, it generates text files that can be version-controlled to isolate that input in the future. Unfortunately, we lose that info in the CI runs; this commit is an attempt to change that, so we can inspect a failing CI run in the future and reproduce the failing test locally to understand the conditions better.

[0] https://github.com/penumbra-zone/jmt/actions/runs/4950336820/attempts/1
[1] https://github.com/penumbra-zone/jmt/actions/runs/4950336820