### PR TITLE
Remove HardCoded sha2; Add Blake3 Tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ publish = true
 [features]
 default = ["ics23", "std", "sha2"]
 mocks = ["dep:parking_lot"]
+blake3_tests = ["dep:blake3"]
 std = ["dep:thiserror"]
 
 [dependencies]
@@ -33,6 +34,7 @@ parking_lot = { version = "0.12.1", optional = true }
 serde = { version = "1.0.124", features = ["derive"] }
 thiserror = { version = "1.0.24", optional = true } 
 sha2 = { version = "0.10", optional = true } 
+blake3 = { version = "1.4.0", optional = true, features = ["traits-preview"] } 
 hex = "0.4"
 tracing = "0.1"
 ics23 = { version = "0.10.0", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ category = ["cryptography", "data-structures"]
 publish = true
 
 [features]
-default = ["ics23", "std"]
+default = ["ics23", "std", "sha2"]
 mocks = ["dep:parking_lot"]
 std = ["dep:thiserror"]
 
 [dependencies]
 anyhow = "1.0.38"
 borsh =  "0.10.0" 
+digest = "0.10" 
 hashbrown = "0.13.2"
 itertools = { version = "0.10.0", default-features = false }
 mirai-annotations = "1.10.1"
@@ -31,7 +32,7 @@ num-traits = "0.2.14"
 parking_lot = { version = "0.12.1", optional = true } 
 serde = { version = "1.0.124", features = ["derive"] }
 thiserror = { version = "1.0.24", optional = true } 
-sha2 = "0.10"
+sha2 = { version = "0.10", optional = true } 
 hex = "0.4"
 tracing = "0.1"
 ics23 = { version = "0.10.0", optional = true}
@@ -43,3 +44,4 @@ parking_lot = { version = "0.12.1" }
 serde_json = { version  = "1.0.95" }
 proptest = { version = "1.0.0" }
 proptest-derive = { version = "0.3.0" }
+sha2 = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,9 @@ pub trait SimpleHasher: Sized {
 /// structs to derive these traits even if the concrete hasher does not
 /// implement them.
 #[derive(Clone, Eq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
-pub struct PhantomHasher<H: SimpleHasher>(core::marker::PhantomData<H>);
+pub struct PhantomHasher<H: SimpleHasher>(
+    #[serde(bound(serialize = "", deserialize = ""))] core::marker::PhantomData<H>,
+);
 
 impl<H: SimpleHasher> Debug for PhantomHasher<H> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,10 @@ extern crate alloc;
 
 use core::fmt::Debug;
 
+use digest::generic_array::GenericArray;
+use digest::Digest;
+use digest::OutputSizeUser;
 use serde::{Deserialize, Serialize};
-use sha2::digest::generic_array::GenericArray;
-use sha2::digest::OutputSizeUser;
-use sha2::Digest;
 #[cfg(feature = "std")]
 use thiserror::Error;
 
@@ -97,7 +97,10 @@ use bytes32ext::Bytes32Ext;
 pub use iterator::JellyfishMerkleIterator;
 #[cfg(feature = "ics23")]
 pub use tree::ics23_impl::ics23_spec;
-pub use tree::{JellyfishMerkleTree, Sha256Jmt};
+pub use tree::JellyfishMerkleTree;
+#[cfg(any(test, feature = "sha2"))]
+pub use tree::Sha256Jmt;
+
 use types::nibble::ROOT_NIBBLE_HEIGHT;
 pub use types::proof;
 pub use types::Version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,51 +290,6 @@ pub trait SimpleHasher: Sized {
     }
 }
 
-/// A wrapper around `core::marker::Phatomdata` which implements
-/// Debug, PartialEq, Eq, and Clone  This allows higher level
-/// structs to derive these traits even if the concrete hasher does not
-/// implement them.
-#[derive(Eq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
-pub struct PhantomHasher<H: SimpleHasher>(
-    #[serde(bound(serialize = "", deserialize = ""))] core::marker::PhantomData<H>,
-);
-
-#[cfg(any(test, feature = "fuzzing"))]
-impl<H: SimpleHasher> proptest::prelude::Arbitrary for PhantomHasher<H> {
-    type Parameters = ();
-    type Strategy = proptest::strategy::Just<Self>;
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        proptest::strategy::Just(Default::default())
-    }
-}
-
-impl<H: SimpleHasher> Clone for PhantomHasher<H> {
-    fn clone(&self) -> Self {
-        Self(Default::default())
-    }
-}
-
-impl<H: SimpleHasher> Debug for PhantomHasher<H> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PhantomHasher")
-            .field(&stringify!(H))
-            .finish()
-    }
-}
-
-impl<H: SimpleHasher> PartialEq for PhantomHasher<H> {
-    fn eq(&self, _other: &Self) -> bool {
-        true
-    }
-}
-
-impl<H: SimpleHasher> Default for PhantomHasher<H> {
-    fn default() -> Self {
-        Self(core::marker::PhantomData)
-    }
-}
-
 impl<T: Digest> SimpleHasher for T
 where
     [u8; 32]: From<GenericArray<u8, <T as OutputSizeUser>::OutputSize>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,10 +294,26 @@ pub trait SimpleHasher: Sized {
 /// Debug, PartialEq, Eq, and Clone  This allows higher level
 /// structs to derive these traits even if the concrete hasher does not
 /// implement them.
-#[derive(Clone, Eq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
+#[derive(Eq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct PhantomHasher<H: SimpleHasher>(
     #[serde(bound(serialize = "", deserialize = ""))] core::marker::PhantomData<H>,
 );
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl<H: SimpleHasher> proptest::prelude::Arbitrary for PhantomHasher<H> {
+    type Parameters = ();
+    type Strategy = proptest::strategy::Just<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        proptest::strategy::Just(Default::default())
+    }
+}
+
+impl<H: SimpleHasher> Clone for PhantomHasher<H> {
+    fn clone(&self) -> Self {
+        Self(Default::default())
+    }
+}
 
 impl<H: SimpleHasher> Debug for PhantomHasher<H> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -5,6 +5,8 @@
 //! [`JellyfishMerkleTree`](crate::JellyfishMerkleTree) from small chunks of
 //! key/value pairs.
 
+use core::marker::PhantomData;
+
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::{sync::Arc, vec::Vec};
@@ -26,8 +28,8 @@ use crate::{
         proof::{SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleRangeProof},
         Version,
     },
-    Bytes32Ext, KeyHash, OwnedValue, PhantomHasher, RootHash, SimpleHasher, ValueHash,
-    ROOT_NIBBLE_HEIGHT, SPARSE_MERKLE_PLACEHOLDER_HASH,
+    Bytes32Ext, KeyHash, OwnedValue, RootHash, SimpleHasher, ValueHash, ROOT_NIBBLE_HEIGHT,
+    SPARSE_MERKLE_PLACEHOLDER_HASH,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -166,7 +168,7 @@ pub struct JellyfishMerkleRestore<H: SimpleHasher> {
     /// Whether to use the new internal node format where leaf counts are written.
     leaf_count_migration: bool,
 
-    _phantom_hasher: PhantomHasher<H>,
+    _phantom_hasher: PhantomData<H>,
 }
 
 impl<H: SimpleHasher> JellyfishMerkleRestore<H> {

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -46,7 +46,7 @@ enum ChildInfo {
 
 impl ChildInfo {
     /// Converts `self` to a child, assuming the hash is known if it's an internal node.
-    fn into_child(self, version: Version) -> Child {
+    fn into_child<H: SimpleHasher>(self, version: Version) -> Child {
         match self {
             Self::Internal { hash, leaf_count } => Child::new(
                 hash.expect("Must have been initialized."),
@@ -55,7 +55,7 @@ impl ChildInfo {
                     .map(|n| NodeType::Internal { leaf_count: n })
                     .unwrap_or(NodeType::InternalLegacy),
             ),
-            Self::Leaf { node } => Child::new(node.hash(), version, NodeType::Leaf),
+            Self::Leaf { node } => Child::new(node.hash::<H>(), version, NodeType::Leaf),
         }
     }
 }
@@ -86,7 +86,7 @@ impl InternalInfo {
 
     /// Converts `self` to an internal node, assuming all of its children are already known and
     /// fully initialized.
-    fn into_internal_node(
+    fn into_internal_node<H: SimpleHasher>(
         mut self,
         version: Version,
         leaf_count_migration: bool,
@@ -97,7 +97,7 @@ impl InternalInfo {
         // https://github.com/rust-lang/rust/issues/25725. So we use `iter_mut` and `take`.
         for (index, child_info_option) in self.children.iter_mut().enumerate() {
             if let Some(child_info) = child_info_option.take() {
-                children.insert((index as u8).into(), child_info.into_child(version));
+                children.insert((index as u8).into(), child_info.into_child::<H>(version));
             }
         }
 
@@ -263,7 +263,7 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
                 if let Some(node) = store.get_node_option(&child_node_key)? {
                     let child_info = match node {
                         Node::Internal(internal_node) => ChildInfo::Internal {
-                            hash: Some(internal_node.hash()),
+                            hash: Some(internal_node.hash::<H>()),
                             leaf_count: internal_node.leaf_count(),
                         },
                         Node::Leaf(leaf_node) => ChildInfo::Leaf { node: leaf_node },
@@ -305,7 +305,7 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
     fn add_chunk_impl(
         &mut self,
         chunk: Vec<(KeyHash, OwnedValue)>,
-        proof: SparseMerkleRangeProof,
+        proof: SparseMerkleRangeProof<H>,
     ) -> Result<()> {
         ensure!(!chunk.is_empty(), "Should not add empty chunks.");
 
@@ -511,10 +511,10 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
         while self.partial_nodes.len() > num_remaining_nodes {
             let last_node = self.partial_nodes.pop().expect("This node must exist.");
             let (node_key, internal_node) =
-                last_node.into_internal_node(self.version, self.leaf_count_migration);
+                last_node.into_internal_node::<H>(self.version, self.leaf_count_migration);
             // Keep the hash of this node before moving it into `frozen_nodes`, so we can update
             // its parent later.
-            let node_hash = internal_node.hash();
+            let node_hash = internal_node.hash::<H>();
             let node_leaf_count = internal_node.leaf_count();
             self.frozen_nodes
                 .insert_node(node_key, internal_node.into());
@@ -550,7 +550,7 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
     /// `self.previous_leaf`) are correct, i.e., we are able to construct `self.expected_root_hash`
     /// by combining all existing accounts and `proof`.
     #[allow(clippy::collapsible_if)]
-    fn verify(&self, proof: SparseMerkleRangeProof) -> Result<()> {
+    fn verify(&self, proof: SparseMerkleRangeProof<H>) -> Result<()> {
         let previous_leaf = self
             .previous_leaf
             .as_ref()
@@ -639,7 +639,7 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
                 Some(ChildInfo::Internal { hash, .. }) => {
                     (*hash.as_ref().expect("The hash must be known."), false)
                 }
-                Some(ChildInfo::Leaf { node }) => (node.hash(), true),
+                Some(ChildInfo::Leaf { node }) => (node.hash::<H>(), true),
                 None => (SPARSE_MERKLE_PLACEHOLDER_HASH, true),
             }
         } else {
@@ -654,7 +654,7 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
                 (left_hash, true)
             } else {
                 (
-                    SparseMerkleInternalNode::new(left_hash, right_hash).hash(),
+                    SparseMerkleInternalNode::<H>::new(left_hash, right_hash).hash(),
                     false,
                 )
             }
@@ -694,11 +694,11 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
 }
 
 /// The interface used with [`JellyfishMerkleRestore`], taken from the Diem `storage-interface` crate.
-pub trait StateSnapshotReceiver {
+pub trait StateSnapshotReceiver<H: SimpleHasher> {
     fn add_chunk(
         &mut self,
         chunk: Vec<(KeyHash, OwnedValue)>,
-        proof: SparseMerkleRangeProof,
+        proof: SparseMerkleRangeProof<H>,
     ) -> Result<()>;
 
     fn finish(self) -> Result<()>;
@@ -706,11 +706,11 @@ pub trait StateSnapshotReceiver {
     fn finish_box(self: Box<Self>) -> Result<()>;
 }
 
-impl<H: SimpleHasher> StateSnapshotReceiver for JellyfishMerkleRestore<H> {
+impl<H: SimpleHasher> StateSnapshotReceiver<H> for JellyfishMerkleRestore<H> {
     fn add_chunk(
         &mut self,
         chunk: Vec<(KeyHash, OwnedValue)>,
-        proof: SparseMerkleRangeProof,
+        proof: SparseMerkleRangeProof<H>,
     ) -> Result<()> {
         self.add_chunk_impl(chunk, proof)
     }

--- a/src/tests/jellyfish_merkle.rs
+++ b/src/tests/jellyfish_merkle.rs
@@ -116,11 +116,11 @@ fn test_insert_at_leaf_with_internal_created() {
     let mut children = Children::new();
     children.insert(
         Nibble::from(0),
-        Child::new(leaf1.hash(), 1 /* version */, NodeType::Leaf),
+        Child::new(leaf1.hash::<Sha256>(), 1 /* version */, NodeType::Leaf),
     );
     children.insert(
         Nibble::from(15),
-        Child::new(leaf2.hash(), 1 /* version */, NodeType::Leaf),
+        Child::new(leaf2.hash::<Sha256>(), 1 /* version */, NodeType::Leaf),
     );
     let internal = Node::new_internal(children);
     assert_eq!(db.get_node(&NodeKey::new_empty_path(0)).unwrap(), leaf1);
@@ -183,11 +183,11 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
         let mut children = Children::new();
         children.insert(
             Nibble::from(0),
-            Child::new(leaf1.hash(), 1 /* version */, NodeType::Leaf),
+            Child::new(leaf1.hash::<Sha256>(), 1 /* version */, NodeType::Leaf),
         );
         children.insert(
             Nibble::from(1),
-            Child::new(leaf2.hash(), 1 /* version */, NodeType::Leaf),
+            Child::new(leaf2.hash::<Sha256>(), 1 /* version */, NodeType::Leaf),
         );
         Node::new_internal(children)
     };
@@ -197,7 +197,7 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
         children.insert(
             Nibble::from(0),
             Child::new(
-                internal.hash(),
+                internal.hash::<Sha256>(),
                 1, /* version */
                 NodeType::Internal { leaf_count: 2 },
             ),

--- a/src/tests/jellyfish_merkle.rs
+++ b/src/tests/jellyfish_merkle.rs
@@ -709,12 +709,12 @@ fn test_two_gets_then_delete() {
 proptest! {
     #[test]
     fn proptest_get_with_proof((existent_kvs, nonexistent_keys) in arb_existent_kvs_and_nonexistent_keys(1000, 100)) {
-        test_get_with_proof((existent_kvs, nonexistent_keys))
+        test_get_with_proof::<Sha256>((existent_kvs, nonexistent_keys))
     }
 
     #[test]
     fn proptest_get_with_proof_with_deletions((existent_kvs, deletions, nonexistent_keys) in arb_existent_kvs_and_deletions_and_nonexistent_keys(1000, 100)) {
-        test_get_with_proof_with_deletions((existent_kvs, deletions, nonexistent_keys))
+        test_get_with_proof_with_deletions::<Sha256>((existent_kvs, deletions, nonexistent_keys))
     }
 
     // This is a replica of the test below, with the values tuned to the smallest values that were
@@ -729,7 +729,7 @@ proptest! {
                         .prop_flat_map(move |ops| arb_partitions(versions, ops))
             })
     ) {
-        test_clairvoyant_construction_matches_interleaved_construction(operations_by_version)
+        test_clairvoyant_construction_matches_interleaved_construction::<Sha256>(operations_by_version)
     }
 
     // This is a replica of the test above, but with much larger parameters for more exhaustive
@@ -745,21 +745,21 @@ proptest! {
                         .prop_flat_map(move |ops| arb_partitions(versions, ops))
             })
     ) {
-        test_clairvoyant_construction_matches_interleaved_construction(operations_by_version)
+        test_clairvoyant_construction_matches_interleaved_construction::<Sha256>(operations_by_version)
     }
 
     #[test]
     fn proptest_get_with_proof_with_distinct_last_nibble((kv1, kv2) in arb_kv_pair_with_distinct_last_nibble()) {
-        test_get_with_proof_with_distinct_last_nibble((kv1, kv2))
+        test_get_with_proof_with_distinct_last_nibble::<Sha256>((kv1, kv2))
     }
 
     #[test]
     fn proptest_get_range_proof((btree, n) in arb_tree_with_index(1000)) {
-        test_get_range_proof((btree, n))
+        test_get_range_proof::<Sha256>((btree, n))
     }
 
     #[test]
     fn proptest_get_leaf_count(keys in btree_set(any::<KeyHash>(), 1..1000).prop_map(|m| m.into_iter().collect())) {
-        test_get_leaf_count(keys)
+        test_get_leaf_count::<Sha256>(keys)
     }
 }

--- a/src/tests/node_type.rs
+++ b/src/tests/node_type.rs
@@ -21,11 +21,11 @@ use crate::{
 };
 
 fn hash_internal(left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
-    SparseMerkleInternalNode::new(left, right).hash()
+    SparseMerkleInternalNode::<Sha256>::new(left, right).hash()
 }
 
 fn hash_leaf(key: KeyHash, value_hash: ValueHash) -> [u8; 32] {
-    SparseMerkleLeafNode::new(key, value_hash).hash()
+    SparseMerkleLeafNode::<Sha256>::new(key, value_hash).hash()
 }
 
 // Generate a random node key with 63 nibbles.
@@ -86,7 +86,7 @@ fn test_leaf_hash() {
         let value_hash = ValueHash::with::<Sha256>(blob.as_slice());
         let hash = hash_leaf(address, value_hash);
         let leaf_node = Node::leaf_from_value::<Sha256>(address, blob);
-        assert_eq!(leaf_node.hash(), hash);
+        assert_eq!(leaf_node.hash::<Sha256>(), hash);
     }
 }
 
@@ -113,17 +113,17 @@ proptest! {
         //        leaf1     leaf2
         //
         let root_hash = hash_internal(hash1, hash2);
-        prop_assert_eq!(internal_node.hash(), root_hash);
+        prop_assert_eq!(internal_node.hash::<Sha256>(), root_hash);
 
         for i in 0..8 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (Some(leaf1_node_key.clone()), vec![hash2])
             );
         }
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (Some(leaf2_node_key.clone()), vec![hash1])
             );
         }
@@ -160,18 +160,18 @@ proptest! {
         let hash_x2 = hash_internal(SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x1);
 
         let root_hash = hash_internal(hash_x2, SPARSE_MERKLE_PLACEHOLDER_HASH);
-        assert_eq!(internal_node.hash(), root_hash);
+        assert_eq!(internal_node.hash::<Sha256>(), root_hash);
 
         for i in 0..4 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x1])
             );
         }
 
         for i in 4..6 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (
                     Some(leaf1_node_key.clone()),
                     vec![
@@ -185,7 +185,7 @@ proptest! {
 
         for i in 6..8 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (
                     Some(leaf2_node_key.clone()),
                     vec![
@@ -199,7 +199,7 @@ proptest! {
 
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![hash_x2])
             );
         }
@@ -234,25 +234,25 @@ proptest! {
         //      leaf1     leaf2
         let hash_x = hash_internal(hash1, hash2);
         let root_hash = hash_internal(hash_x, hash3);
-        prop_assert_eq!(internal_node.hash(), root_hash);
+        prop_assert_eq!(internal_node.hash::<Sha256>(), root_hash);
 
         for i in 0..4 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (Some(leaf1_node_key.clone()),vec![hash3, hash2])
             );
         }
 
         for i in 4..8 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (Some(leaf2_node_key.clone()),vec![hash3, hash1])
             );
         }
 
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (Some(leaf3_node_key.clone()),vec![hash_x])
             );
         }
@@ -299,11 +299,11 @@ proptest! {
         let hash_x4 = hash_internal(SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x3);
         let hash_x5 = hash_internal(hash_x2, hash_x4);
         let root_hash = hash_internal(hash_x5, hash4);
-        assert_eq!(internal_node.hash(), root_hash);
+        assert_eq!(internal_node.hash::<Sha256>(), root_hash);
 
         for i in 0..2 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (
                     Some(leaf1_node_key.clone()),
                     vec![hash4, hash_x4, hash_x1]
@@ -312,7 +312,7 @@ proptest! {
         }
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, 2.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 2.into()),
             (
                 Some(internal2_node_key),
                 vec![
@@ -325,7 +325,7 @@ proptest! {
         );
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, 3.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 3.into()),
 
             (
                 None,
@@ -335,7 +335,7 @@ proptest! {
 
         for i in 4..6 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (
                     None,
                     vec![hash4, hash_x2, hash_x3]
@@ -344,7 +344,7 @@ proptest! {
         }
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, 6.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 6.into()),
             (
                 None,
                 vec![
@@ -357,7 +357,7 @@ proptest! {
         );
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, 7.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 7.into()),
             (
                 Some(internal3_node_key),
                 vec![
@@ -371,7 +371,7 @@ proptest! {
 
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (Some(leaf4_node_key.clone()), vec![hash_x5])
             );
         }
@@ -433,17 +433,17 @@ fn test_internal_hash_and_proof() {
         let hash_x5 = hash_internal(SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x4);
         let hash_x6 = hash_internal(SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x5);
         let root_hash = hash_internal(hash_x3, hash_x6);
-        assert_eq!(internal_node.hash(), root_hash);
+        assert_eq!(internal_node.hash::<Sha256>(), root_hash);
 
         for i in 0..4 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![hash_x6, hash_x2])
             );
         }
 
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, index1),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, index1),
             (
                 Some(child1_node_key),
                 vec![
@@ -456,7 +456,7 @@ fn test_internal_hash_and_proof() {
         );
 
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, 5.into()),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 5.into()),
             (
                 None,
                 vec![
@@ -469,26 +469,26 @@ fn test_internal_hash_and_proof() {
         );
         for i in 6..8 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![hash_x6, SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x1])
             );
         }
 
         for i in 8..12 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![hash_x3, hash_x5])
             );
         }
 
         for i in 12..14 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![hash_x3, SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x4])
             );
         }
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, 14.into()),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 14.into()),
             (
                 None,
                 vec![
@@ -500,7 +500,7 @@ fn test_internal_hash_and_proof() {
             )
         );
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, index2),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, index2),
             (
                 Some(child2_node_key),
                 vec![
@@ -566,10 +566,10 @@ fn test_internal_hash_and_proof() {
         let hash_x4 = hash_internal(SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x3);
         let hash_x5 = hash_internal(hash_x2, hash_x4);
         let root_hash = hash_internal(hash_x5, SPARSE_MERKLE_PLACEHOLDER_HASH);
-        assert_eq!(internal_node.hash(), root_hash);
+        assert_eq!(internal_node.hash::<Sha256>(), root_hash);
 
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, 0.into()),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 0.into()),
             (
                 Some(child1_node_key),
                 vec![
@@ -582,7 +582,7 @@ fn test_internal_hash_and_proof() {
         );
 
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, 1.into()),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 1.into()),
             (
                 None,
                 vec![
@@ -596,20 +596,20 @@ fn test_internal_hash_and_proof() {
 
         for i in 2..4 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x4, hash_x1])
             );
         }
 
         for i in 4..6 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![SPARSE_MERKLE_PLACEHOLDER_HASH, hash_x2, hash_x3])
             );
         }
 
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, 6.into()),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 6.into()),
             (
                 None,
                 vec![
@@ -622,7 +622,7 @@ fn test_internal_hash_and_proof() {
         );
 
         assert_eq!(
-            internal_node.get_child_with_siblings(&internal_node_key, 7.into()),
+            internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, 7.into()),
             (
                 Some(child2_node_key),
                 vec![
@@ -636,7 +636,7 @@ fn test_internal_hash_and_proof() {
 
         for i in 8..16 {
             assert_eq!(
-                internal_node.get_child_with_siblings(&internal_node_key, i.into()),
+                internal_node.get_child_with_siblings::<Sha256>(&internal_node_key, i.into()),
                 (None, vec![hash_x5])
             );
         }
@@ -665,7 +665,7 @@ impl BinaryTreeNode {
         left: BinaryTreeNode,
         right: BinaryTreeNode,
     ) -> Self {
-        let hash = SparseMerkleInternalNode::new(left.hash(), right.hash()).hash();
+        let hash = SparseMerkleInternalNode::<Sha256>::new(left.hash(), right.hash()).hash();
 
         Self::Internal(BinaryTreeInternalNode {
             begin: first_child_index,
@@ -813,7 +813,7 @@ proptest! {
     ) {
         for n in 0..16u8 {
             prop_assert_eq!(
-                node.get_child_with_siblings(&node_key, n.into()),
+                node.get_child_with_siblings::<Sha256>(&node_key, n.into()),
                 NaiveInternalNode::from_clever_node(&node).get_child_with_siblings(&node_key, n)
             )
         }

--- a/src/tests/restore.rs
+++ b/src/tests/restore.rs
@@ -1,5 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
+// #![cfg(feature = "sha2")]
 
 use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 
@@ -11,99 +12,108 @@ use crate::{
     restore::{JellyfishMerkleRestore, StateSnapshotReceiver},
     storage::TreeReader,
     tests::helper::init_mock_db,
-    KeyHash, OwnedValue, RootHash, Sha256Jmt, Version,
+    JellyfishMerkleTree, KeyHash, OwnedValue, RootHash, Sha256Jmt, SimpleHasher, Version,
 };
+
+fn test_restore_with_interruption<H: SimpleHasher>(
+    entries: BTreeMap<KeyHash, OwnedValue>,
+    first_batch_size: usize,
+) {
+    let (db, version) = init_mock_db::<H>(&entries.clone().into_iter().collect());
+    let tree = JellyfishMerkleTree::<_, H>::new(&db);
+    let expected_root_hash = tree.get_root_hash(version).unwrap();
+    let batch1: Vec<_> = entries.clone().into_iter().take(first_batch_size).collect();
+
+    let restore_db = Arc::new(MockTreeStore::default());
+    {
+        let mut restore = JellyfishMerkleRestore::<H>::new(
+            Arc::clone(&restore_db),
+            version,
+            expected_root_hash,
+            true, /* leaf_count_migraion */
+        )
+        .unwrap();
+        let proof = tree
+            .get_range_proof(batch1.last().map(|(key, _value)| *key).unwrap(), version)
+            .unwrap();
+        restore
+            .add_chunk(batch1.into_iter().collect(), proof)
+            .unwrap();
+        // Do not call `finish`.
+    }
+
+    {
+        let rightmost_key = match restore_db.get_rightmost_leaf().unwrap() {
+            None => {
+                // Sometimes the batch is too small so nothing is written to DB.
+                return;
+            }
+            Some((_, node)) => node.key_hash(),
+        };
+        let remaining_accounts: Vec<_> = entries
+            .clone()
+            .into_iter()
+            .filter(|(k, _v)| *k > rightmost_key)
+            .collect();
+
+        let mut restore = JellyfishMerkleRestore::<H>::new(
+            Arc::clone(&restore_db),
+            version,
+            expected_root_hash,
+            true, /* leaf_count_migration */
+        )
+        .unwrap();
+        let proof = tree
+            .get_range_proof(
+                remaining_accounts.last().map(|(key, _value)| *key).unwrap(),
+                version,
+            )
+            .unwrap();
+        restore
+            .add_chunk(remaining_accounts.into_iter().collect(), proof)
+            .unwrap();
+        restore.finish().unwrap();
+    }
+
+    assert_success(&restore_db, expected_root_hash, &entries, version);
+}
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
     #[test]
-    fn test_restore_without_interruption(
+    fn test_restore_without_interruption_sha256(
         btree in btree_map(any::<KeyHash>(), any::<OwnedValue>(), 1..1000),
         target_version in 0u64..2000,
     ) {
         let restore_db = Arc::new(MockTreeStore::default());
         // For this test, restore everything without interruption.
-        restore_without_interruption(&btree, target_version, &restore_db, true);
+        restore_without_interruption::<Sha256>(&btree, target_version, &restore_db, true);
     }
 
     #[test]
-    fn test_restore_with_interruption(
-        (all, batch1_size) in btree_map(any::<KeyHash>(), any::<OwnedValue>(), 2..1000)
+    fn test_restore_with_interruption_sha256(
+        (entries, first_batch_size) in btree_map(any::<KeyHash>(), any::<OwnedValue>(), 2..1000)
             .prop_flat_map(|btree| {
                 let len = btree.len();
                 (Just(btree), 1..len)
             })
     ) {
-        let (db, version) = init_mock_db(
-            &all.clone()
-                .into_iter()
-                .collect()
-        );
-        let tree = Sha256Jmt::new(&db);
-        let expected_root_hash = tree.get_root_hash(version).unwrap();
-        let batch1: Vec<_> = all.clone().into_iter().take(batch1_size).collect();
-
-        let restore_db = Arc::new(MockTreeStore::default());
-        {
-            let mut restore = JellyfishMerkleRestore::<Sha256>::new(
-                Arc::clone(&restore_db), version, expected_root_hash, true /* leaf_count_migraion */
-            ).unwrap();
-            let proof = tree
-                .get_range_proof(batch1.last().map(|(key, _value)| *key).unwrap(), version)
-                .unwrap();
-            restore.add_chunk(
-                batch1.into_iter()
-                    .collect(),
-                proof
-            ).unwrap();
-            // Do not call `finish`.
-        }
-
-        {
-            let rightmost_key = match restore_db.get_rightmost_leaf().unwrap() {
-                None => {
-                    // Sometimes the batch is too small so nothing is written to DB.
-                    return Ok(());
-                }
-                Some((_, node)) => node.key_hash(),
-            };
-            let remaining_accounts: Vec<_> = all
-                .clone()
-                .into_iter()
-                .filter(|(k, _v)| *k > rightmost_key)
-                .collect();
-
-            let mut restore = JellyfishMerkleRestore::<Sha256>::new(
-                 Arc::clone(&restore_db), version, expected_root_hash, true /* leaf_count_migration */
-            ).unwrap();
-            let proof = tree
-                .get_range_proof(
-                    remaining_accounts.last().map(|(key, _value)| *key).unwrap(),
-                    version,
-                )
-                .unwrap();
-            restore.add_chunk(
-                remaining_accounts.into_iter()
-                    .collect(),
-                proof
-            ).unwrap();
-            restore.finish().unwrap();
-        }
-
-        assert_success(&restore_db, expected_root_hash, &all, version);
+        test_restore_with_interruption::<Sha256>(entries, first_batch_size )
     }
 
+
+
     #[test]
-    fn test_overwrite(
+    fn test_overwrite_sha256(
         btree1 in btree_map(any::<KeyHash>(), any::<OwnedValue>(), 1..1000),
         btree2 in btree_map(any::<KeyHash>(), any::<OwnedValue>(), 1..1000),
         target_version in 0u64..2000,
     ) {
         let restore_db = Arc::new(MockTreeStore::new(true /* allow_overwrite */));
-        restore_without_interruption(&btree1, target_version, &restore_db, true);
+        restore_without_interruption::<Sha256>(&btree1, target_version, &restore_db, true);
         // overwrite, an entirely different tree
-        restore_without_interruption(&btree2, target_version, &restore_db, false);
+        restore_without_interruption::<Sha256>(&btree2, target_version, &restore_db, false);
     }
 }
 
@@ -122,13 +132,13 @@ fn assert_success(
     assert_eq!(actual_root_hash, expected_root_hash);
 }
 
-fn restore_without_interruption(
+fn restore_without_interruption<H: SimpleHasher>(
     btree: &BTreeMap<KeyHash, OwnedValue>,
     target_version: Version,
     target_db: &Arc<MockTreeStore>,
     try_resume: bool,
 ) {
-    let (db, source_version) = init_mock_db(&btree.clone().into_iter().collect());
+    let (db, source_version) = init_mock_db::<H>(&btree.clone().into_iter().collect());
     let tree = Sha256Jmt::new(&db);
     let expected_root_hash = tree.get_root_hash(source_version).unwrap();
 

--- a/src/tests/tree_cache.rs
+++ b/src/tests/tree_cache.rs
@@ -84,12 +84,12 @@ fn test_freeze_with_delete() {
         .unwrap();
     assert_eq!(cache.get_node(&node1_key).unwrap(), node1);
     assert_eq!(cache.get_node(&node2_key).unwrap(), node2);
-    cache.freeze().unwrap();
+    cache.freeze::<Sha256>().unwrap();
     assert_eq!(cache.get_node(&node1_key).unwrap(), node1);
     assert_eq!(cache.get_node(&node2_key).unwrap(), node2);
 
     cache.delete_node(&node1_key, true /* is_leaf */);
-    cache.freeze().unwrap();
+    cache.freeze::<Sha256>().unwrap();
     let (_, update_batch) = cache.into();
     assert_eq!(update_batch.node_batch.nodes().len(), 3);
     assert_eq!(update_batch.stale_node_index_batch.len(), 1);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -74,7 +74,7 @@ where
                 None => unreachable!("{:?} can not be found in hash cache", node_key),
             }
         } else {
-            node.hash()
+            node.hash::<H>()
         }
     }
 
@@ -121,7 +121,7 @@ where
             tree_cache.set_root_node_key(new_root_node_key);
 
             // Freezes the current cache to make all contents in the current cache immutable.
-            tree_cache.freeze()?;
+            tree_cache.freeze::<H>()?;
         }
 
         Ok(tree_cache.into())
@@ -292,7 +292,7 @@ where
                     node_key.gen_child_node_key(version, existing_leaf_bucket);
                 children.insert(
                     existing_leaf_bucket,
-                    Child::new(existing_leaf_node.hash(), version, NodeType::Leaf),
+                    Child::new(existing_leaf_node.hash::<H>(), version, NodeType::Leaf),
                 );
 
                 tree_cache.put_node(existing_leaf_node_key, existing_leaf_node.into())?;
@@ -431,7 +431,7 @@ where
                         })
                 })?;
             // Freezes the current cache to make all contents in the current cache immutable.
-            tree_cache.freeze()?;
+            tree_cache.freeze::<H>()?;
         }
 
         Ok(tree_cache.into())
@@ -586,7 +586,7 @@ where
                 // update child
                 children.insert(
                     child_index,
-                    Child::new(new_node.hash(), version, new_node.node_type()),
+                    Child::new(new_node.hash::<H>(), version, new_node.node_type()),
                 );
             }
             PutResult::Removed => {
@@ -701,7 +701,7 @@ where
             let mut children = Children::new();
             children.insert(
                 existing_leaf_index,
-                Child::new(existing_leaf_node.hash(), version, NodeType::Leaf),
+                Child::new(existing_leaf_node.hash::<H>(), version, NodeType::Leaf),
             );
             node_key = NodeKey::new(version, common_nibble_path.clone());
             tree_cache.put_node(
@@ -717,7 +717,7 @@ where
             )?;
             children.insert(
                 new_leaf_index,
-                Child::new(new_leaf_node.hash(), version, NodeType::Leaf),
+                Child::new(new_leaf_node.hash::<H>(), version, NodeType::Leaf),
             );
 
             let internal_node = InternalNode::new_migration(children, self.leaf_count_migration);
@@ -733,7 +733,7 @@ where
                 children.insert(
                     nibble,
                     Child::new(
-                        next_internal_node.hash(),
+                        next_internal_node.hash::<H>(),
                         version,
                         next_internal_node.node_type(),
                     ),
@@ -801,8 +801,8 @@ where
                     let queried_child_index = nibble_iter
                         .next()
                         .ok_or_else(|| format_err!("ran out of nibbles"))?;
-                    let (child_node_key, mut siblings_in_internal) =
-                        internal_node.get_child_with_siblings(&next_node_key, queried_child_index);
+                    let (child_node_key, mut siblings_in_internal) = internal_node
+                        .get_child_with_siblings::<H>(&next_node_key, queried_child_index);
                     siblings.append(&mut siblings_in_internal);
                     next_node_key = match child_node_key {
                         Some(node_key) => node_key,
@@ -1137,7 +1137,7 @@ where
         &self,
         rightmost_key_to_prove: KeyHash,
         version: Version,
-    ) -> Result<SparseMerkleRangeProof> {
+    ) -> Result<SparseMerkleRangeProof<H>> {
         let (account, proof) = self.get_with_proof(rightmost_key_to_prove, version)?;
         ensure!(account.is_some(), "rightmost_key_to_prove must exist.");
 
@@ -1178,13 +1178,13 @@ where
     }
 
     pub fn get_root_hash(&self, version: Version) -> Result<RootHash> {
-        self.get_root_node(version).map(|n| RootHash(n.hash()))
+        self.get_root_node(version).map(|n| RootHash(n.hash::<H>()))
     }
 
     pub fn get_root_hash_option(&self, version: Version) -> Result<Option<RootHash>> {
         Ok(self
             .get_root_node_option(version)?
-            .map(|n| RootHash(n.hash())))
+            .map(|n| RootHash(n.hash::<H>())))
     }
 
     // TODO: should this be public? seems coupled to tests?

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,7 +8,6 @@ use hashbrown::HashMap;
 use std::collections::HashMap;
 
 use anyhow::{bail, ensure, format_err, Context, Result};
-use sha2::Sha256;
 
 use crate::{
     node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey, NodeType},
@@ -27,7 +26,8 @@ use crate::{
 
 /// A [`JellyfishMerkleTree`] instantiated using the `sha2::Sha256` hasher.
 /// This is a sensible default choice for most applications.
-pub type Sha256Jmt<'a, R> = JellyfishMerkleTree<'a, R, Sha256>;
+#[cfg(any(test, feature = "sha2"))]
+pub type Sha256Jmt<'a, R> = JellyfishMerkleTree<'a, R, sha2::Sha256>;
 
 /// A Jellyfish Merkle tree data structure, parameterized by a [`TreeReader`] `R`
 /// and a [`SimpleHasher`] `H`. See [`crate`] for description.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,6 @@
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloc::{format, vec};
+use core::marker::PhantomData;
 use core::{cmp::Ordering, convert::TryInto};
 #[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
@@ -21,8 +22,7 @@ use crate::{
         proof::{SparseMerkleProof, SparseMerkleRangeProof},
         Version,
     },
-    Bytes32Ext, KeyHash, MissingRootError, OwnedValue, PhantomHasher, RootHash, SimpleHasher,
-    ValueHash,
+    Bytes32Ext, KeyHash, MissingRootError, OwnedValue, RootHash, SimpleHasher, ValueHash,
 };
 
 /// A [`JellyfishMerkleTree`] instantiated using the `sha2::Sha256` hasher.
@@ -34,7 +34,7 @@ pub type Sha256Jmt<'a, R> = JellyfishMerkleTree<'a, R, Sha256>;
 pub struct JellyfishMerkleTree<'a, R, H: SimpleHasher> {
     reader: &'a R,
     leaf_count_migration: bool,
-    _phantom_hasher: PhantomHasher<H>,
+    _phantom_hasher: PhantomData<H>,
 }
 
 #[cfg(feature = "ics23")]

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -80,7 +80,7 @@ use crate::{
         NodeBatch, NodeStats, StaleNodeIndex, StaleNodeIndexBatch, TreeReader, TreeUpdateBatch,
     },
     types::{Version, PRE_GENESIS_VERSION},
-    KeyHash, OwnedValue, RootHash,
+    KeyHash, OwnedValue, RootHash, SimpleHasher,
 };
 
 /// `FrozenTreeCache` is used as a field of `TreeCache` storing all the nodes and values that
@@ -255,7 +255,7 @@ where
     }
 
     /// Freezes all the contents in cache to be immutable and clear `node_cache`.
-    pub fn freeze(&mut self) -> Result<()> {
+    pub fn freeze<H: SimpleHasher>(&mut self) -> Result<()> {
         let mut root_node_key = self.get_root_node_key().clone();
 
         let root_node = if let Some(root_node) = self.get_node_option(&root_node_key)? {
@@ -273,7 +273,7 @@ where
         // they can be extracted later after a sequence of transactions:
         self.frozen_cache
             .root_hashes
-            .push(RootHash(root_node.hash()));
+            .push(RootHash(root_node.hash::<H>()));
 
         // If the effect of this set of changes has been to do nothing, we still need to create a
         // new root node that matches the anticipated version; we do this by copying the previous

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -7,62 +7,103 @@ pub(crate) mod definition;
 #[cfg(any(test, feature = "fuzzing"))]
 pub(crate) mod proptest_proof;
 
-#[cfg(any(test, feature = "fuzzing"))]
-use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 pub use self::definition::{SparseMerkleProof, SparseMerkleRangeProof};
-use crate::{KeyHash, ValueHash};
+use crate::{KeyHash, PhantomHasher, SimpleHasher, ValueHash};
 
 pub const LEAF_DOMAIN_SEPARATOR: &[u8] = b"JMT::LeafNode";
 pub const INTERNAL_DOMAIN_SEPARATOR: &[u8] = b"JMT::IntrnalNode";
 
-pub(crate) struct SparseMerkleInternalNode {
+pub(crate) struct SparseMerkleInternalNode<H: SimpleHasher> {
     left_child: [u8; 32],
     right_child: [u8; 32],
+    _phantom: PhantomHasher<H>,
 }
 
-impl SparseMerkleInternalNode {
+impl<H: SimpleHasher> SparseMerkleInternalNode<H> {
     pub fn new(left_child: [u8; 32], right_child: [u8; 32]) -> Self {
         Self {
             left_child,
             right_child,
+            _phantom: Default::default(),
         }
     }
 
     pub fn hash(&self) -> [u8; 32] {
-        use sha2::Digest;
-        let mut hasher = sha2::Sha256::new();
+        let mut hasher = H::new();
         // chop a vowel to fit in 16 bytes
         hasher.update(INTERNAL_DOMAIN_SEPARATOR);
-        hasher.update(self.left_child);
-        hasher.update(self.right_child);
-        *hasher.finalize().as_ref()
+        hasher.update(&self.left_child);
+        hasher.update(&self.right_child);
+        hasher.finalize()
     }
 }
 
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct SparseMerkleLeafNode {
+#[derive(Eq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
+pub struct SparseMerkleLeafNode<H: SimpleHasher> {
     key_hash: KeyHash,
     value_hash: ValueHash,
+    #[serde(bound(serialize = "", deserialize = ""))]
+    _phantom: PhantomHasher<H>,
 }
 
-impl SparseMerkleLeafNode {
+// Manually implement Arbitrary to get the correct bounds (proptest_derive) only allows all-or-nothing,
+// but we need H: SimpleHasher only.
+#[cfg(any(test, feature = "fuzzing"))]
+impl<H: SimpleHasher> proptest::arbitrary::Arbitrary for SparseMerkleLeafNode<H> {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        use proptest::{arbitrary::any, strategy::Strategy};
+        (any::<KeyHash>(), any::<ValueHash>())
+            .prop_map(|(key_hash, value_hash)| Self {
+                key_hash,
+                value_hash,
+                _phantom: Default::default(),
+            })
+            .boxed()
+    }
+}
+// Manually implement Clone to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> Clone for SparseMerkleLeafNode<H> {
+    fn clone(&self) -> Self {
+        Self {
+            key_hash: self.key_hash.clone(),
+            value_hash: self.value_hash.clone(),
+            _phantom: self._phantom.clone(),
+        }
+    }
+}
+
+// Manually implement Debug to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> core::fmt::Debug for SparseMerkleLeafNode<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SparseMerkleLeafNode")
+            .field("key_hash", &self.key_hash)
+            .field("value_hash", &self.value_hash)
+            .field("_phantom", &self._phantom)
+            .finish()
+    }
+}
+
+// Manually implement PartialEq to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> PartialEq for SparseMerkleLeafNode<H> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key_hash == other.key_hash && self.value_hash == other.value_hash
+    }
+}
+
+impl<H: SimpleHasher> SparseMerkleLeafNode<H> {
     pub(crate) fn new(key_hash: KeyHash, value_hash: ValueHash) -> Self {
         SparseMerkleLeafNode {
             key_hash,
             value_hash,
+            _phantom: Default::default(),
         }
     }
 
@@ -71,11 +112,10 @@ impl SparseMerkleLeafNode {
     }
 
     pub(crate) fn hash(&self) -> [u8; 32] {
-        use sha2::Digest;
-        let mut hasher = sha2::Sha256::new();
+        let mut hasher = H::new();
         hasher.update(LEAF_DOMAIN_SEPARATOR);
-        hasher.update(self.key_hash.0);
-        hasher.update(self.value_hash.0);
-        *hasher.finalize().as_ref()
+        hasher.update(&self.key_hash.0);
+        hasher.update(&self.value_hash.0);
+        hasher.finalize()
     }
 }

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -50,8 +50,8 @@ pub struct SparseMerkleLeafNode<H> {
     _phantom: PhantomData<H>,
 }
 
-// Manually implement Arbitrary to get the correct bounds (proptest_derive) only allows all-or-nothing,
-// but we need H: SimpleHasher only.
+// Manually implement Arbitrary to get the correct bounds. The derived Arbitrary impl adds a spurious
+// H: Debug bound even with the proptest(no_bound) annotation
 #[cfg(any(test, feature = "fuzzing"))]
 impl<H> proptest::arbitrary::Arbitrary for SparseMerkleLeafNode<H> {
     type Parameters = ();
@@ -68,6 +68,7 @@ impl<H> proptest::arbitrary::Arbitrary for SparseMerkleLeafNode<H> {
             .boxed()
     }
 }
+
 // Manually implement Clone to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
 // TODO: Switch back to #[derive] once the perfect_derive feature lands
 impl<H> Clone for SparseMerkleLeafNode<H> {

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -46,7 +46,6 @@ impl<H: SimpleHasher> SparseMerkleInternalNode<H> {
 pub struct SparseMerkleLeafNode<H> {
     key_hash: KeyHash,
     value_hash: ValueHash,
-    #[serde(bound(serialize = "", deserialize = ""))]
     _phantom: PhantomData<H>,
 }
 

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -27,6 +27,7 @@ pub struct SparseMerkleProof<H> {
     ///           corresponding account blob.
     ///     - If this is `None`, this is also a non-inclusion proof which indicates the subtree is
     ///       empty.
+    // Prevent serde from adding a spurious Serialize/Deserialize bound on H
     #[serde(bound(serialize = "", deserialize = ""))]
     leaf: Option<SparseMerkleLeafNode<H>>,
 
@@ -35,7 +36,6 @@ pub struct SparseMerkleProof<H> {
     siblings: Vec<[u8; 32]>,
 
     /// A marker type showing which hash function is used in this proof.
-    #[serde(bound(serialize = "", deserialize = ""))]
     phantom_hasher: PhantomData<H>,
 }
 
@@ -261,7 +261,7 @@ pub struct SparseMerkleRangeProof<H> {
     /// The vector of siblings on the right of the path from root to last leaf. The ones near the
     /// bottom are at the beginning of the vector. In the above example, it's `[X, h]`.
     right_siblings: Vec<[u8; 32]>,
-    #[serde(bound(serialize = "", deserialize = ""))]
+    #[serde(skip)]
     _phantom: PhantomData<H>,
 }
 

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -372,14 +372,14 @@ mod tests {
                 KeyHash([1u8; 32]),
                 ValueHash([2u8; 32]),
             )),
-            siblings: vec![[3u8; 32], [4u8; 32]],
+            siblings: alloc::vec![[3u8; 32], [4u8; 32]],
             phantom_hasher: Default::default(),
         }
     }
 
     fn get_test_range_proof() -> SparseMerkleRangeProof<Sha256> {
         SparseMerkleRangeProof {
-            right_siblings: vec![[3u8; 32], [4u8; 32]],
+            right_siblings: alloc::vec![[3u8; 32], [4u8; 32]],
             _phantom: Default::default(),
         }
     }

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -261,7 +261,6 @@ pub struct SparseMerkleRangeProof<H> {
     /// The vector of siblings on the right of the path from root to last leaf. The ones near the
     /// bottom are at the beginning of the vector. In the above example, it's `[X, h]`.
     right_siblings: Vec<[u8; 32]>,
-    #[serde(skip)]
     _phantom: PhantomData<H>,
 }
 
@@ -359,7 +358,11 @@ impl<H: SimpleHasher> SparseMerkleRangeProof<H> {
 }
 
 #[cfg(test)]
-mod tests {
+mod serialization_tests {
+    //! These tests ensure that the various proofs supported by the JMT can actually be serialized and deserialized
+    //! when instantiated with a specific hasher. This is done as a sanity check to ensure the trait bounds inferred by Rustc
+    //! are not too restrictive.
+
     use sha2::Sha256;
 
     use crate::{proof::SparseMerkleLeafNode, KeyHash, ValueHash};

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -15,9 +15,7 @@ use crate::{
 
 /// A proof that can be used to authenticate an element in a Sparse Merkle Tree given trusted root
 /// hash. For example, `TransactionInfoToAccountProof` can be constructed on top of this structure.
-#[derive(
-    Clone, Eq, PartialEq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize,
-)]
+#[derive(Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct SparseMerkleProof<H: SimpleHasher> {
     /// This proof can be used to authenticate whether a given leaf exists in the tree or not.
     ///     - If this is `Some(leaf_node)`
@@ -28,13 +26,15 @@ pub struct SparseMerkleProof<H: SimpleHasher> {
     ///           corresponding account blob.
     ///     - If this is `None`, this is also a non-inclusion proof which indicates the subtree is
     ///       empty.
-    leaf: Option<SparseMerkleLeafNode>,
+    #[serde(bound(serialize = "", deserialize = ""))]
+    leaf: Option<SparseMerkleLeafNode<H>>,
 
     /// All siblings in this proof, including the default ones. Siblings are ordered from the bottom
     /// level to the root level.
     siblings: Vec<[u8; 32]>,
 
     /// A marker type showing which hash function is used in this proof.
+    #[serde(bound(serialize = "", deserialize = ""))]
     phantom_hasher: PhantomHasher<H>,
 }
 
@@ -50,9 +50,29 @@ impl<H: SimpleHasher> core::fmt::Debug for SparseMerkleProof<H> {
     }
 }
 
+// Manually implement PartialEq to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> PartialEq for SparseMerkleProof<H> {
+    fn eq(&self, other: &Self) -> bool {
+        self.leaf == other.leaf && self.siblings == other.siblings
+    }
+}
+
+// Manually implement Clone to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> Clone for SparseMerkleProof<H> {
+    fn clone(&self) -> Self {
+        Self {
+            leaf: self.leaf.clone(),
+            siblings: self.siblings.clone(),
+            phantom_hasher: Default::default(),
+        }
+    }
+}
+
 impl<H: SimpleHasher> SparseMerkleProof<H> {
     /// Constructs a new `SparseMerkleProof` using leaf and a list of siblings.
-    pub(crate) fn new(leaf: Option<SparseMerkleLeafNode>, siblings: Vec<[u8; 32]>) -> Self {
+    pub(crate) fn new(leaf: Option<SparseMerkleLeafNode<H>>, siblings: Vec<[u8; 32]>) -> Self {
         SparseMerkleProof {
             leaf,
             siblings,
@@ -61,8 +81,8 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
     }
 
     /// Returns the leaf node in this proof.
-    pub fn leaf(&self) -> Option<SparseMerkleLeafNode> {
-        self.leaf
+    pub fn leaf(&self) -> Option<SparseMerkleLeafNode<H>> {
+        self.leaf.clone()
     }
 
     /// Returns the list of siblings in this proof.
@@ -108,7 +128,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
             self.siblings.len(),
         );
 
-        match (element_value, self.leaf) {
+        match (element_value, self.leaf.clone()) {
             (Some(value), Some(leaf)) => {
                 // This is an inclusion proof, so the key and value hash provided in the proof
                 // should match element_key and element_value_hash. `siblings` should prove the
@@ -154,6 +174,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
 
         let current_hash = self
             .leaf
+            .clone()
             .map_or(SPARSE_MERKLE_PLACEHOLDER_HASH, |leaf| leaf.hash());
         let actual_root_hash = self
             .siblings
@@ -167,9 +188,9 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
             )
             .fold(current_hash, |hash, (sibling_hash, bit)| {
                 if bit {
-                    SparseMerkleInternalNode::new(*sibling_hash, hash).hash()
+                    SparseMerkleInternalNode::<H>::new(*sibling_hash, hash).hash()
                 } else {
-                    SparseMerkleInternalNode::new(hash, *sibling_hash).hash()
+                    SparseMerkleInternalNode::<H>::new(hash, *sibling_hash).hash()
                 }
             });
         ensure!(
@@ -185,6 +206,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
     pub fn root_hash(&self) -> RootHash {
         let current_hash = self
             .leaf
+            .clone()
             .map_or(SPARSE_MERKLE_PLACEHOLDER_HASH, |leaf| leaf.hash());
         let actual_root_hash = self
             .siblings
@@ -200,9 +222,9 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
             )
             .fold(current_hash, |hash, (sibling_hash, bit)| {
                 if bit {
-                    SparseMerkleInternalNode::new(*sibling_hash, hash).hash()
+                    SparseMerkleInternalNode::<H>::new(*sibling_hash, hash).hash()
                 } else {
-                    SparseMerkleInternalNode::new(hash, *sibling_hash).hash()
+                    SparseMerkleInternalNode::<H>::new(hash, *sibling_hash).hash()
                 }
             });
 
@@ -233,26 +255,52 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
 ///
 /// if the proof wants show that `[a, b, c, d, e]` exists in the tree, it would need the siblings
 /// `X` and `h` on the right.
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-)]
-pub struct SparseMerkleRangeProof {
+#[derive(Eq, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
+pub struct SparseMerkleRangeProof<H: SimpleHasher> {
     /// The vector of siblings on the right of the path from root to last leaf. The ones near the
     /// bottom are at the beginning of the vector. In the above example, it's `[X, h]`.
     right_siblings: Vec<[u8; 32]>,
+    #[serde(bound(serialize = "", deserialize = ""))]
+    _phantom: PhantomHasher<H>,
 }
 
-impl SparseMerkleRangeProof {
+// Manually implement PartialEq to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> PartialEq for SparseMerkleRangeProof<H> {
+    fn eq(&self, other: &Self) -> bool {
+        self.right_siblings == other.right_siblings
+    }
+}
+
+// Manually implement Clone to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> Clone for SparseMerkleRangeProof<H> {
+    fn clone(&self) -> Self {
+        Self {
+            right_siblings: self.right_siblings.clone(),
+            _phantom: self._phantom.clone(),
+        }
+    }
+}
+
+// Manually implement Debug to circumvent [incorrect auto-bounds](https://github.com/rust-lang/rust/issues/26925)
+// TODO: Switch back to #[derive] once the perfect_derive feature lands
+impl<H: SimpleHasher> core::fmt::Debug for SparseMerkleRangeProof<H> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SparseMerkleRangeProof")
+            .field("right_siblings", &self.right_siblings)
+            .field("_phantom", &self._phantom)
+            .finish()
+    }
+}
+
+impl<H: SimpleHasher> SparseMerkleRangeProof<H> {
     /// Constructs a new `SparseMerkleRangeProof`.
     pub(crate) fn new(right_siblings: Vec<[u8; 32]>) -> Self {
-        Self { right_siblings }
+        Self {
+            right_siblings,
+            _phantom: Default::default(),
+        }
     }
 
     /// Returns the right siblings.
@@ -265,7 +313,7 @@ impl SparseMerkleRangeProof {
     pub fn verify(
         &self,
         expected_root_hash: RootHash,
-        rightmost_known_leaf: SparseMerkleLeafNode,
+        rightmost_known_leaf: SparseMerkleLeafNode<H>,
         left_siblings: Vec<[u8; 32]>,
     ) -> Result<()> {
         let num_siblings = left_siblings.len() + self.right_siblings.len();
@@ -295,7 +343,7 @@ impl SparseMerkleRangeProof {
                         .ok_or_else(|| format_err!("Missing right sibling."))?,
                 )
             };
-            current_hash = SparseMerkleInternalNode::new(left_hash, right_hash).hash();
+            current_hash = SparseMerkleInternalNode::<H>::new(left_hash, right_hash).hash();
         }
 
         ensure!(
@@ -306,5 +354,76 @@ impl SparseMerkleRangeProof {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::Sha256;
+
+    use crate::{proof::SparseMerkleLeafNode, KeyHash, ValueHash};
+
+    use super::{SparseMerkleProof, SparseMerkleRangeProof};
+
+    fn get_test_proof() -> SparseMerkleProof<Sha256> {
+        SparseMerkleProof {
+            leaf: Some(SparseMerkleLeafNode::new(
+                KeyHash([1u8; 32]),
+                ValueHash([2u8; 32]),
+            )),
+            siblings: vec![[3u8; 32], [4u8; 32]],
+            phantom_hasher: Default::default(),
+        }
+    }
+
+    fn get_test_range_proof() -> SparseMerkleRangeProof<Sha256> {
+        SparseMerkleRangeProof {
+            right_siblings: vec![[3u8; 32], [4u8; 32]],
+            _phantom: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_sparse_merkle_proof_roundtrip_serde() {
+        let proof = get_test_proof();
+        let serialized_proof = serde_json::to_string(&proof).expect("serialization is infallible");
+        let deserialized =
+            serde_json::from_str(&serialized_proof).expect("serialized proof is valid");
+
+        assert_eq!(proof, deserialized);
+    }
+
+    #[test]
+    fn test_sparse_merkle_proof_roundtrip_borsh() {
+        use borsh::{BorshDeserialize, BorshSerialize};
+        let proof = get_test_proof();
+        let serialized_proof = proof.try_to_vec().expect("serialization is infallible");
+        let deserialized =
+            SparseMerkleProof::<Sha256>::deserialize(&mut serialized_proof.as_slice())
+                .expect("serialized proof is valid");
+
+        assert_eq!(proof, deserialized);
+    }
+
+    #[test]
+    fn test_sparse_merkle_range_proof_roundtrip_serde() {
+        let proof = get_test_range_proof();
+        let serialized_proof = serde_json::to_string(&proof).expect("serialization is infallible");
+        let deserialized =
+            serde_json::from_str(&serialized_proof).expect("serialized proof is valid");
+
+        assert_eq!(proof, deserialized);
+    }
+
+    #[test]
+    fn test_sparse_merkle_range_proof_roundtrip_borsh() {
+        use borsh::{BorshDeserialize, BorshSerialize};
+        let proof = get_test_range_proof();
+        let serialized_proof = proof.try_to_vec().expect("serialization is infallible");
+        let deserialized =
+            SparseMerkleRangeProof::<Sha256>::deserialize(&mut serialized_proof.as_slice())
+                .expect("serialized proof is valid");
+
+        assert_eq!(proof, deserialized);
     }
 }

--- a/src/types/proof/proptest_proof.rs
+++ b/src/types/proof/proptest_proof.rs
@@ -25,13 +25,13 @@ fn arb_sparse_merkle_sibling() -> impl Strategy<Value = [u8; 32]> {
     ]
 }
 
-impl<H: SimpleHasher> Arbitrary for SparseMerkleProof<H> {
+impl<H: SimpleHasher + 'static> Arbitrary for SparseMerkleProof<H> {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (
-            any::<Option<SparseMerkleLeafNode>>(),
+            any::<Option<SparseMerkleLeafNode<H>>>(),
             (0..=256usize).prop_flat_map(|len| {
                 if len == 0 {
                     Just(Vec::new()).boxed()
@@ -53,7 +53,7 @@ impl<H: SimpleHasher> Arbitrary for SparseMerkleProof<H> {
     }
 }
 
-impl Arbitrary for SparseMerkleRangeProof {
+impl<H: SimpleHasher + 'static> Arbitrary for SparseMerkleRangeProof<H> {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
 


### PR DESCRIPTION
## Overview
A previous PR made the JMT generic over hash function. At that time, however, we did not implement any tests using a different hasher. As a result, we didn't catch that the implementations of `InternalNode` and `LeafNode` still had hidden `sha2` invocations hardcoded. Oops! This PR fixes those issues, and adds some tests using `blake3`.

In addition, the previous work had not modified the various proof types supported by the JMT (`SparseMerkleProof`, `SparseMerkleRangeProof`, etc.). This PR also makes those types generic over hash.

Finally, the PR makes a few small tweaks related to type inference and trait bounds - notably removing the `PhantomHasher` type and using `PhantomData` in its place. 

## Future Work
1. Manually generate test vectors for `blake3`
2. Add `blake3` versions of remaining unit/integration tests
3. Write additional macros to support creation of test suites for additional hashers, if desired