### PR TITLE
Preston/simplify update proofs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,13 +154,31 @@ pub type OwnedValue = alloc::vec::Vec<u8>;
 use proptest_derive::Arbitrary;
 
 /// A root of a [`JellyfishMerkleTree`].
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+)]
 #[cfg_attr(any(test), derive(Arbitrary))]
 pub struct RootHash(pub [u8; 32]);
 
 impl From<RootHash> for [u8; 32] {
     fn from(value: RootHash) -> Self {
         value.0
+    }
+}
+
+impl From<[u8; 32]> for RootHash {
+    fn from(value: [u8; 32]) -> Self {
+        Self(value)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,12 @@ use proptest_derive::Arbitrary;
 #[cfg_attr(any(test), derive(Arbitrary))]
 pub struct RootHash(pub [u8; 32]);
 
+impl From<RootHash> for [u8; 32] {
+    fn from(value: RootHash) -> Self {
+        value.0
+    }
+}
+
 /// A hashed key used to index a [`JellyfishMerkleTree`].
 ///
 /// # 🚨 Danger 🚨

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,12 @@ impl From<RootHash> for [u8; 32] {
     }
 }
 
+impl AsRef<[u8]> for RootHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 /// A hashed key used to index a [`JellyfishMerkleTree`].
 ///
 /// # 🚨 Danger 🚨

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -375,7 +375,7 @@ where
         &self,
         value_set: impl IntoIterator<Item = (KeyHash, Option<OwnedValue>)>,
         version: Version,
-    ) -> Result<(RootHash, UpdateMerkleProof<H, OwnedValue>, TreeUpdateBatch)> {
+    ) -> Result<(RootHash, UpdateMerkleProof<H>, TreeUpdateBatch)> {
         let (mut hash_and_proof, batch_update) =
             self.put_value_sets_with_proof(vec![value_set], version)?;
         assert_eq!(
@@ -465,10 +465,7 @@ where
         &self,
         value_sets: impl IntoIterator<Item = impl IntoIterator<Item = (KeyHash, Option<OwnedValue>)>>,
         first_version: Version,
-    ) -> Result<(
-        Vec<(RootHash, UpdateMerkleProof<H, OwnedValue>)>,
-        TreeUpdateBatch,
-    )> {
+    ) -> Result<(Vec<(RootHash, UpdateMerkleProof<H>)>, TreeUpdateBatch)> {
         let mut tree_cache = TreeCache::new(self.reader, first_version)?;
         let mut batch_proofs = Vec::new();
         for (idx, value_set) in value_sets.into_iter().enumerate() {
@@ -488,7 +485,7 @@ where
                     })?
                     .unwrap();
 
-                proofs.push((merkle_proof, key, value));
+                proofs.push(merkle_proof);
             }
 
             batch_proofs.push(UpdateMerkleProof::new(proofs));

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -15,7 +15,7 @@ use crate::{
 #[cfg(all(test, feature = "std"))]
 use proptest_derive::Arbitrary;
 
-pub use self::definition::{SparseMerkleProof, SparseMerkleRangeProof};
+pub use self::definition::{SparseMerkleProof, SparseMerkleRangeProof, UpdateMerkleProof};
 use crate::{KeyHash, ValueHash, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -510,7 +510,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct UpdateMerkleProof<H: SimpleHasher, V: AsRef<[u8]>>(
     Vec<(SparseMerkleProof<H>, KeyHash, Option<V>)>,
 );

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -511,15 +511,11 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
 }
 
 #[derive(Debug, Serialize, Deserialize, borsh::BorshSerialize, borsh::BorshDeserialize)]
-pub struct UpdateMerkleProof<H: SimpleHasher, V: AsRef<[u8]>>(
-    Vec<(SparseMerkleProof<H>, KeyHash, Option<V>)>,
-);
+pub struct UpdateMerkleProof<H: SimpleHasher>(Vec<SparseMerkleProof<H>>);
 
-impl<H: SimpleHasher, V: AsRef<[u8]>> UpdateMerkleProof<H, V> {
-    pub fn new(
-        merkle_proof_and_new_key_values: Vec<(SparseMerkleProof<H>, KeyHash, Option<V>)>,
-    ) -> Self {
-        UpdateMerkleProof(merkle_proof_and_new_key_values)
+impl<H: SimpleHasher> UpdateMerkleProof<H> {
+    pub fn new(merkle_proofs: Vec<SparseMerkleProof<H>>) -> Self {
+        UpdateMerkleProof(merkle_proofs)
     }
 
     /// Verifies an update of the [`JellyfishMerkleTree`], proving the transition from an `old_root_hash` to a `new_root_hash` ([`RootHash`])
@@ -534,16 +530,29 @@ impl<H: SimpleHasher, V: AsRef<[u8]>> UpdateMerkleProof<H, V> {
     /// If these steps are verified then the [`JellyfishMerkleTree`] has been soundly updated
     ///
     /// This function consumes the Merkle proof to avoid uneccessary copying.
-    pub fn verify_update(self, old_root_hash: RootHash, new_root_hash: RootHash) -> Result<()> {
-        let merkle_proof_and_new_key_values = self.0;
+    pub fn verify_update<V: AsRef<[u8]>>(
+        self,
+        old_root_hash: RootHash,
+        new_root_hash: RootHash,
+        updates: impl AsRef<[(KeyHash, Option<V>)]>,
+    ) -> Result<()> {
+        let updates = updates.as_ref();
+        ensure!(
+            updates.len() == self.0.len(),
+            "Mismatched number of updates and proofs. Received {} proofs for {} updates",
+            self.0.len(),
+            updates.len()
+        );
         let mut curr_root_hash = old_root_hash;
 
-        for (merkle_proof, new_element_key, new_element_value) in merkle_proof_and_new_key_values {
+        for (merkle_proof, (new_element_key, new_element_value)) in
+            self.0.into_iter().zip(updates.iter())
+        {
             // Checks the old root hash and computes the new root
             curr_root_hash = merkle_proof.check_compute_new_root(
                 curr_root_hash,
-                new_element_key,
-                new_element_value,
+                *new_element_key,
+                new_element_value.as_ref(),
             )?;
         }
 


### PR DESCRIPTION
This PR makes two improvements to the recently added updates proofs:
1. Make proofs serializable (with both `borsh` and `serde`
2. Accept the set of updates as an argument to the `verify_update` method instead of internalizing it into the proof. This is more space efficient (when proofs need to be stored or sent over the network), and saves the verifier from having to check that their observed update set matches the proof.