### PR TITLE
jmt: use latest ics23 spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ sha2 = { version = "0.10", optional = true }
 blake3 = { version = "1.4.0", optional = true, features = ["traits-preview"] } 
 hex = "0.4"
 tracing = "0.1"
-ics23 = { version = "0.10.0", optional = true}
+ics23 = { version = "0.11.0", optional = true}
 
 [dev-dependencies]
 hex = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmt"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Penumbra Labs <team@penumbra.zone>",
     "Diem Association <opensource@diem.com>",


### PR DESCRIPTION
This PR switches the jmt to `ics23@0.11` and prepares release `v0.9.0`