### PR TITLE
jmt: allow incremental tree overwrites for a given version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["ics23", "std", "sha2"]
 mocks = ["dep:parking_lot"]
 blake3_tests = ["dep:blake3"]
 std = ["dep:thiserror"]
+migration = []
 
 [dependencies]
 anyhow = "1.0.38"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ impl KeyHash {
 impl core::fmt::Debug for KeyHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("KeyHash")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }
@@ -263,7 +263,7 @@ impl core::fmt::Debug for KeyHash {
 impl core::fmt::Debug for ValueHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("ValueHash")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }
@@ -271,7 +271,7 @@ impl core::fmt::Debug for ValueHash {
 impl core::fmt::Debug for RootHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("RootHash")
-            .field(&hex::encode(&self.0))
+            .field(&hex::encode(self.0))
             .finish()
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -446,33 +446,36 @@ where
     }
 
     #[cfg(feature = "migration")]
-    /// Append value sets to the latest version of the tree.
-    pub fn append_value_sets(
+    /// Append value sets to the latest version of the tree, without incrementing its version.
+    pub fn append_value_set(
         &self,
-        value_sets: impl IntoIterator<Item = impl IntoIterator<Item = (KeyHash, Option<OwnedValue>)>>,
+        value_set: impl IntoIterator<Item = (KeyHash, Option<OwnedValue>)>,
         latest_version: Version,
-    ) -> Result<(Vec<RootHash>, TreeUpdateBatch)> {
+    ) -> Result<(RootHash, TreeUpdateBatch)> {
         let mut tree_cache = TreeCache::new_overwrite(self.reader, latest_version)?;
-        for (idx, value_set) in value_sets.into_iter().enumerate() {
-            let version = latest_version + idx as u64;
-            for (i, (key, value)) in value_set.into_iter().enumerate() {
-                let action = if value.is_some() { "insert" } else { "delete" };
-                let value_hash = value.as_ref().map(|v| ValueHash::with::<H>(v));
-                tree_cache.put_value(version, key, value);
-                self.put(key, value_hash, version, &mut tree_cache, false)
-                    .with_context(|| {
-                        format!(
-                            "failed to {} key {} for version {}, key = {:?}",
-                            action, i, version, key
-                        )
-                    })?;
-            }
-
-            // Freezes the current cache to make all contents in the current cache immutable.
-            tree_cache.freeze::<H>()?;
+        for (i, (key, value)) in value_set.into_iter().enumerate() {
+            let action = if value.is_some() { "insert" } else { "delete" };
+            let value_hash = value.as_ref().map(|v| ValueHash::with::<H>(v));
+            tree_cache.put_value(latest_version, key, value);
+            self.put(key, value_hash, latest_version, &mut tree_cache, false)
+                .with_context(|| {
+                    format!(
+                        "failed to {} key {} for version {}, key = {:?}",
+                        action, i, latest_version, key
+                    )
+                })?;
         }
 
-        Ok(tree_cache.into())
+        // Freezes the current cache to make all contents in the current cache immutable.
+        tree_cache.freeze::<H>()?;
+        let (root_hash_vec, tree_batch) = tree_cache.into();
+        if root_hash_vec.len() != 1 {
+            bail!(
+                "appending a value set failed, we expected a single root hash, but got {}",
+                root_hash_vec.len()
+            );
+        }
+        Ok((root_hash_vec[0], tree_batch))
     }
 
     /// Same as [`put_value_sets`], this method returns a Merkle proof for every update of the Merkle tree.

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -200,7 +200,7 @@ where
             stale_node_index_cache: HashSet::new(),
             frozen_cache: FrozenTreeCache::new(),
             root_node_key,
-            next_version: current_version + 1,
+            next_version: current_version,
             reader,
             num_stale_leaves: 0,
             num_new_leaves: 0,

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -72,7 +72,7 @@ use hashbrown::{hash_map::Entry, HashMap, HashSet};
 #[cfg(feature = "std")]
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, Result};
 
 use crate::{
     node_type::{Node, NodeKey},
@@ -201,7 +201,7 @@ where
             bail!("creating an overwrite cache for an empty tree is not supported")
         };
 
-        ensure!(
+        anyhow::ensure!(
             node_key.version() == current_version,
             "the supplied version is not the latest version of the tree"
         );

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -188,6 +188,27 @@ where
         })
     }
 
+    #[cfg(feature = "migration")]
+    pub fn new_overwrite(
+        reader: &'a R,
+        current_version: Version,
+        root_node_key: NodeKey,
+    ) -> Result<Self> {
+        let mut node_cache = HashMap::new();
+        let root_node_key = NodeKey::new_empty_path(current_version);
+        Ok(Self {
+            node_cache,
+            stale_node_index_cache: HashSet::new(),
+            frozen_cache: FrozenTreeCache::new(),
+            root_node_key,
+            next_version: current_version + 1,
+            reader,
+            num_stale_leaves: 0,
+            num_new_leaves: 0,
+            value_cache: Default::default(),
+        })
+    }
+
     /// Gets a node with given node key. If it doesn't exist in node cache, read from `reader`.
     pub fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
         Ok(if let Some(node) = self.node_cache.get(node_key) {

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -192,9 +192,8 @@ where
     pub fn new_overwrite(
         reader: &'a R,
         current_version: Version,
-        root_node_key: NodeKey,
     ) -> Result<Self> {
-        let mut node_cache = HashMap::new();
+        let node_cache = HashMap::new();
         let root_node_key = NodeKey::new_empty_path(current_version);
         Ok(Self {
             node_cache,

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -189,10 +189,7 @@ where
     }
 
     #[cfg(feature = "migration")]
-    pub fn new_overwrite(
-        reader: &'a R,
-        current_version: Version,
-    ) -> Result<Self> {
+    pub fn new_overwrite(reader: &'a R, current_version: Version) -> Result<Self> {
         let node_cache = HashMap::new();
         let root_node_key = NodeKey::new_empty_path(current_version);
         Ok(Self {


### PR DESCRIPTION
Context: 
Performing offline state migrations without incrementing the tree version: https://github.com/penumbra-zone/penumbra/issues/3506.

This PR adds:
- `TreeCache::new_overwrite` gated behind a `migration` feature. This method instantiate a `TreeCache` against a root node key defined at the current version of the tree (rather than the previous one).
- `JellyfishMerkleTree::append_value_set` gated behind a `migration` feature. This method appends key/values against the current tree (using `new_overwrite`) and return the corresponding node batch.

We validated this approach in https://github.com/penumbra-zone/penumbra/issues/4053