### PR TITLE
jmt: bump version to `0.10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jmt"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Penumbra Labs <team@penumbra.zone>",
     "Diem Association <opensource@diem.com>",


### PR DESCRIPTION
This prepare release `0.10` of the crate.