### PR TITLE
🧺 use typed errors in public interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ tracing = "0.1"
 
 [dev-dependencies]
 hex = { version = "0.4", features = ["serde"] }
-rand = { version = "0.8.3" }
 parking_lot = { version = "0.12.1" } 
-serde_json = { version  = "1.0.95" }
 proptest = { version = "1.0.0" }
 proptest-derive = { version = "0.3.0" }
+rand = { version = "0.8.3" }
+serde_json = { version  = "1.0.95" }
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,21 +24,21 @@ migration = []
 
 [dependencies]
 anyhow = "1.0.38"
+blake3 = { version = "1.4.0", optional = true, features = ["traits-preview"] } 
 borsh = { version = "1.3.0" , features = ["derive", "de_strict_order"]}
 digest = "0.10" 
 hashbrown = "0.13.2"
+hex = "0.4"
+ics23 = { version = "0.11.0", optional = true}
 itertools = { version = "0.10.0", default-features = false }
 mirai-annotations = "1.10.1"
 num-derive = "0.3.3"
 num-traits = "0.2.14"
 parking_lot = { version = "0.12.1", optional = true } 
 serde = { version = "1.0.124", features = ["derive"] }
-thiserror = { version = "1.0.24", optional = true } 
 sha2 = { version = "0.10", optional = true } 
-blake3 = { version = "1.4.0", optional = true, features = ["traits-preview"] } 
-hex = "0.4"
+thiserror = { version = "1.0.24", optional = true } 
 tracing = "0.1"
-ics23 = { version = "0.11.0", optional = true}
 
 [dev-dependencies]
 hex = { version = "0.4", features = ["serde"] }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -12,7 +12,7 @@ use anyhow::{bail, ensure, format_err};
 
 use crate::{
     node_type::{Child, InternalNode, Node, NodeKey},
-    storage::TreeReader,
+    storage::{TreeReader, TreeReaderExt},
     types::{
         nibble::{nibble_path::NibblePath, Nibble, ROOT_NIBBLE_HEIGHT},
         Version,
@@ -117,6 +117,7 @@ pub struct JellyfishMerkleIterator<R> {
 impl<R> JellyfishMerkleIterator<R>
 where
     R: TreeReader,
+    <R as TreeReader>::Error: std::error::Error + Send + Sync + 'static,
 {
     /// Constructs a new iterator. This puts the internal state in the correct position, so the
     /// following `next` call will yield the smallest key that is greater or equal to
@@ -282,6 +283,7 @@ where
 impl<R> Iterator for JellyfishMerkleIterator<R>
 where
     R: TreeReader,
+    <R as TreeReader>::Error: std::error::Error + Send + Sync + 'static,
 {
     type Item = Result<(KeyHash, OwnedValue), anyhow::Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub use types::Version;
 pub mod storage {
     pub use node_type::{LeafNode, Node, NodeKey};
     pub use reader::HasPreimage;
-    pub use reader::TreeReader;
+    pub use reader::{TreeReader, TreeReaderExt};
     pub use types::nibble::nibble_path::NibblePath;
     pub use writer::{
         NodeBatch, NodeStats, StaleNodeIndex, StaleNodeIndexBatch, TreeUpdateBatch, TreeWriter,

--- a/src/node_type.rs
+++ b/src/node_type.rs
@@ -8,30 +8,28 @@
 //! [`JellyfishMerkleTree`](crate::JellyfishMerkleTree). [`InternalNode`] represents a 4-level
 //! binary tree to optimize for IOPS: it compresses a tree with 31 nodes into one node with 16
 //! chidren at the lowest level. [`LeafNode`] stores the full key and the value associated.
-use crate::storage::TreeReader;
 
-use crate::SimpleHasher;
-use alloc::format;
-use alloc::vec::Vec;
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, format, vec::Vec};
+
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::{FromPrimitive, ToPrimitive};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    storage::TreeReader,
+    types::{
+        nibble::{nibble_path::NibblePath, Nibble},
+        proof::{SparseMerkleInternalNode, SparseMerkleLeafNode, SparseMerkleNode},
+        Version,
+    },
+    KeyHash, SimpleHasher, ValueHash, SPARSE_MERKLE_PLACEHOLDER_HASH,
+};
+
 #[cfg(any(test))]
 use proptest::prelude::*;
 #[cfg(any(test))]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
-
-use crate::proof::SparseMerkleNode;
-use crate::{
-    types::{
-        nibble::{nibble_path::NibblePath, Nibble},
-        proof::{SparseMerkleInternalNode, SparseMerkleLeafNode},
-        Version,
-    },
-    KeyHash, ValueHash, SPARSE_MERKLE_PLACEHOLDER_HASH,
-};
 
 /// The unique key of each node.
 #[derive(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use anyhow::{format_err, Result};
+use anyhow::format_err;
 
 use crate::node_type::{LeafNode, Node, NodeKey};
 use crate::{KeyHash, OwnedValue, Version};
@@ -8,25 +8,11 @@ use crate::{KeyHash, OwnedValue, Version};
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
 /// and underlying storage holding nodes.
 pub trait TreeReader {
-    /// Gets node given a node key. Returns error if the node does not exist.
-    fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
-        self.get_node_option(node_key)?
-            .ok_or_else(|| format_err!("Missing node at {:?}.", node_key))
-    }
+    /// The type of error that may be returned by [`TreeReader`] storage lookups.
+    type Error;
 
     /// Gets node given a node key. Returns `None` if the node does not exist.
-    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>>;
-
-    /// Gets a value by identifier, returning the newest value whose version is *less than or
-    /// equal to* the specified version. Returns an error if the value does not exist.
-    fn get_value(&self, max_version: Version, key_hash: KeyHash) -> Result<OwnedValue> {
-        self.get_value_option(max_version, key_hash)?
-            .ok_or_else(|| {
-                format_err!(
-                    "Missing value with max_version {max_version:} and key hash {key_hash:?}."
-                )
-            })
-    }
+    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>, Self::Error>;
 
     /// Gets a value by identifier, returning the newest value whose version is *less than or
     /// equal to* the specified version.  Returns None if the value does not exist.
@@ -34,15 +20,55 @@ pub trait TreeReader {
         &self,
         max_version: Version,
         key_hash: KeyHash,
-    ) -> Result<Option<OwnedValue>>;
+    ) -> Result<Option<OwnedValue>, Self::Error>;
 
     /// Gets the rightmost leaf. Note that this assumes we are in the process of restoring the tree
     /// and all nodes are at the same version.
-    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>>;
+    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>, Self::Error>;
+}
+
+/// Extensions to [`TreeReader`].
+///
+/// These help avoid boilerplate, flattening [`Result<Option<T>, E>`] values into simpler
+/// [`Result<T, E>`] values. [`anyhow::Error`] is used by these methods, use the underlying
+/// [`TreeReader`] methods if you need to use other error types.
+pub trait TreeReaderExt: TreeReader {
+    fn get_node(&self, node_key: &NodeKey) -> Result<Node, anyhow::Error>;
+    fn get_value(
+        &self,
+        max_version: Version,
+        key_hash: KeyHash,
+    ) -> Result<OwnedValue, anyhow::Error>;
+}
+
+impl<T: TreeReader> TreeReaderExt for T
+where
+    T::Error: std::error::Error + Send + Sync + 'static,
+{
+    /// Gets node given a node key. Returns error if the node does not exist.
+    fn get_node(&self, node_key: &NodeKey) -> Result<Node, anyhow::Error> {
+        self.get_node_option(node_key)?
+            .ok_or_else(|| format_err!("Missing node at {:?}.", node_key))
+    }
+
+    /// Gets a value by identifier, returning the newest value whose version is *less than or
+    /// equal to* the specified version. Returns an error if the value does not exist.
+    fn get_value(
+        &self,
+        max_version: Version,
+        key_hash: KeyHash,
+    ) -> Result<OwnedValue, anyhow::Error> {
+        self.get_value_option(max_version, key_hash)?
+            .ok_or_else(|| {
+                format_err!(
+                    "Missing value with max_version {max_version:} and key hash {key_hash:?}."
+                )
+            })
+    }
 }
 
 /// Defines the ability for a tree to look up the preimage of its key hashes.
 pub trait HasPreimage {
     /// Gets the preimage of a key hash, if it is present in the tree.
-    fn preimage(&self, key_hash: KeyHash) -> Result<Option<Vec<u8>>>;
+    fn preimage(&self, key_hash: KeyHash) -> Result<Option<Vec<u8>>, anyhow::Error>;
 }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -7,9 +7,7 @@
 
 use core::marker::PhantomData;
 
-use alloc::boxed::Box;
-use alloc::vec;
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
 use anyhow::{bail, ensure, Result};
 use mirai_annotations::*;

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -595,11 +595,13 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
         left_siblings.reverse();
 
         // Verify the proof now that we have all the siblings
-        proof.verify(
-            self.expected_root_hash,
-            SparseMerkleLeafNode::new(previous_key, previous_leaf.value_hash()),
-            left_siblings,
-        )
+        proof
+            .verify(
+                self.expected_root_hash,
+                SparseMerkleLeafNode::new(previous_key, previous_leaf.value_hash()),
+                left_siblings,
+            )
+            .map_err(Into::into)
     }
 
     /// Computes the sibling on the left for the `n`-th child.

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2,7 +2,7 @@ use crate::{
     node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey, NodeType},
     proof::{definition::UpdateMerkleProof, SparseMerkleLeafNode, SparseMerkleNode},
     storage::{Node::Leaf, TreeReader, TreeReaderExt, TreeUpdateBatch},
-    tree_cache::TreeCache,
+    tree_cache::{NodeAlreadyExists, TreeCache},
     types::{
         nibble::{
             nibble_path::{skip_common_prefix, NibbleIterator, NibblePath},
@@ -1005,7 +1005,7 @@ where
         nibble_iter: &NibbleIterator,
         value_hash: ValueHash,
         tree_cache: &mut TreeCache<R>,
-    ) -> Result<(NodeKey, Node), anyhow::Error> {
+    ) -> Result<(NodeKey, Node), NodeAlreadyExists> {
         // Get the underlying bytes of nibble_iter which must be a key, i.e., hashed account address
         // with `HashValue::LENGTH` bytes.
         let new_leaf_node = Node::new_leaf(

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1321,6 +1321,8 @@ where
             .map(|(nibble, _)| nibble)
         };
 
+        // We limit the number of loops here deliberately to avoid potential cyclic graph bugs
+        // in the tree structure.
         for nibble_depth in nibble_depth..=ROOT_NIBBLE_HEIGHT {
             let node = self.reader.get_node(&node_key).map_err(|err| {
                 if nibble_depth == 0 {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,19 +1,7 @@
-use crate::storage::Node::Leaf;
-use alloc::{collections::BTreeMap, vec::Vec};
-use alloc::{format, vec};
-use anyhow::{bail, ensure, format_err, Context, Result};
-use core::marker::PhantomData;
-use core::{cmp::Ordering, convert::TryInto};
-#[cfg(not(feature = "std"))]
-use hashbrown::HashMap;
-#[cfg(feature = "std")]
-use std::collections::HashMap;
-
-use crate::proof::definition::UpdateMerkleProof;
-use crate::proof::{SparseMerkleLeafNode, SparseMerkleNode};
 use crate::{
     node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey, NodeType},
-    storage::{TreeReader, TreeUpdateBatch},
+    proof::{definition::UpdateMerkleProof, SparseMerkleLeafNode, SparseMerkleNode},
+    storage::{Node::Leaf, TreeReader, TreeUpdateBatch},
     tree_cache::TreeCache,
     types::{
         nibble::{
@@ -25,6 +13,14 @@ use crate::{
     },
     Bytes32Ext, KeyHash, MissingRootError, OwnedValue, RootHash, SimpleHasher, ValueHash,
 };
+use alloc::{collections::BTreeMap, format, vec, vec::Vec};
+use anyhow::{bail, ensure, format_err, Context, Result};
+use core::{cmp::Ordering, convert::TryInto, marker::PhantomData};
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
+use std::collections::HashMap;
 
 /// A [`JellyfishMerkleTree`] instantiated using the `sha2::Sha256` hasher.
 /// This is a sensible default choice for most applications.

--- a/src/tree/ics23_impl.rs
+++ b/src/tree/ics23_impl.rs
@@ -1,6 +1,4 @@
-use alloc::vec;
-use alloc::vec::Vec;
-use anyhow::Result;
+use alloc::{self, vec::Vec};
 
 use crate::{
     proof::{SparseMerkleProof, INTERNAL_DOMAIN_SEPARATOR, LEAF_DOMAIN_SEPARATOR},
@@ -83,7 +81,7 @@ where
         key: Vec<u8>,
         version: Version,
         proof: &ExclusionProof<H>,
-    ) -> Result<ics23::NonExistenceProof> {
+    ) -> Result<ics23::NonExistenceProof, anyhow::Error> {
         match proof {
             ExclusionProof::Leftmost {
                 leftmost_right_proof,
@@ -193,7 +191,7 @@ where
         &self,
         key: Vec<u8>,
         version: Version,
-    ) -> Result<(Option<OwnedValue>, ics23::CommitmentProof)> {
+    ) -> Result<(Option<OwnedValue>, ics23::CommitmentProof), anyhow::Error> {
         let key_hash: KeyHash = KeyHash::with::<H>(key.as_slice());
         let proof_or_exclusion = self.get_with_exclusion_proof(key_hash, version)?;
 

--- a/src/tree/ics23_impl.rs
+++ b/src/tree/ics23_impl.rs
@@ -92,6 +92,7 @@ impl<'a, R, H> JellyfishMerkleTree<'a, R, H>
 where
     R: 'a + TreeReader + HasPreimage,
     H: SimpleHasher,
+    <R as TreeReader>::Error: std::error::Error + Send + Sync + 'static,
 {
     fn exclusion_proof_to_ics23_nonexistence_proof(
         &self,
@@ -115,6 +116,7 @@ where
 
                 let value = self
                     .get(key_hash, version)
+                    .map_err(anyhow::Error::from)
                     .map_err(Ics23ProofError::ValueLookupFailed)?
                     .ok_or(Ics23ProofError::ValueMissing)?;
 
@@ -140,6 +142,7 @@ where
                     .key_hash();
                 let value_leftmost = self
                     .get(leftmost_key_hash, version)
+                    .map_err(anyhow::Error::from)
                     .map_err(Ics23ProofError::ValueLookupFailed)?
                     .ok_or(Ics23ProofError::ValueMissing)?;
                 let key_leftmost = self
@@ -159,6 +162,7 @@ where
                     .key_hash();
                 let value_rightmost = self
                     .get(rightmost_key_hash, version)
+                    .map_err(anyhow::Error::from)
                     .map_err(Ics23ProofError::ValueLookupFailed)?
                     .ok_or(Ics23ProofError::ValueMissing)?;
                 let key_rightmost = self
@@ -187,6 +191,7 @@ where
                     .key_hash();
                 let value_rightmost = self
                     .get(rightmost_key_hash, version)
+                    .map_err(anyhow::Error::from)
                     .map_err(Ics23ProofError::ValueLookupFailed)?
                     .ok_or(Ics23ProofError::ValueMissing)?;
                 let key_rightmost = self

--- a/src/tree_cache.rs
+++ b/src/tree_cache.rs
@@ -175,7 +175,7 @@ where
     <R as TreeReader>::Error: std::error::Error + Send + Sync + 'static,
 {
     /// Constructs a new `TreeCache` instance.
-    pub fn new(reader: &'a R, next_version: Version) -> Result<Self, anyhow::Error> {
+    pub fn new(reader: &'a R, next_version: Version) -> Result<Self, R::Error> {
         let mut node_cache = HashMap::new();
         let root_node_key = if next_version == 0 {
             let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);

--- a/src/types/proof/definition.rs
+++ b/src/types/proof/definition.rs
@@ -11,7 +11,7 @@ use crate::{
     Bytes32Ext, KeyHash, RootHash, SimpleHasher, ValueHash, SPARSE_MERKLE_PLACEHOLDER_HASH,
 };
 use alloc::vec::Vec;
-use anyhow::{bail, ensure, format_err, Result};
+use anyhow::{bail, ensure, format_err};
 use serde::{Deserialize, Serialize};
 
 /// A proof that can be used to authenticate an element in a Sparse Merkle Tree given trusted root
@@ -103,7 +103,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
         expected_root_hash: RootHash,
         element_key: KeyHash,
         element_value: V,
-    ) -> Result<()> {
+    ) -> Result<(), anyhow::Error> {
         self.verify(expected_root_hash, element_key, Some(element_value))
     }
 
@@ -113,7 +113,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
         &self,
         expected_root_hash: RootHash,
         element_key: KeyHash,
-    ) -> Result<()> {
+    ) -> Result<(), anyhow::Error> {
         self.verify(expected_root_hash, element_key, None::<&[u8]>)
     }
 
@@ -126,7 +126,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
         expected_root_hash: RootHash,
         element_key: KeyHash,
         element_value: Option<V>,
-    ) -> Result<()> {
+    ) -> Result<(), anyhow::Error> {
         ensure!(
             self.siblings.len() <= 256,
             "Sparse Merkle Tree proof has more than {} ({}) siblings.",
@@ -306,7 +306,7 @@ impl<H: SimpleHasher> SparseMerkleProof<H> {
         old_root_hash: RootHash,
         new_element_key: KeyHash,
         new_element_value: Option<V>,
-    ) -> Result<RootHash> {
+    ) -> Result<RootHash, anyhow::Error> {
         if let Some(new_element_value) = new_element_value {
             // A value have been supplied, we need to prove that we inserted a given value at the new key
 
@@ -535,7 +535,7 @@ impl<H: SimpleHasher> UpdateMerkleProof<H> {
         old_root_hash: RootHash,
         new_root_hash: RootHash,
         updates: impl AsRef<[(KeyHash, Option<V>)]>,
-    ) -> Result<()> {
+    ) -> Result<(), anyhow::Error> {
         let updates = updates.as_ref();
         ensure!(
             updates.len() == self.0.len(),
@@ -649,7 +649,7 @@ impl<H: SimpleHasher> SparseMerkleRangeProof<H> {
         expected_root_hash: RootHash,
         rightmost_known_leaf: SparseMerkleLeafNode,
         left_siblings: Vec<[u8; 32]>,
-    ) -> Result<()> {
+    ) -> Result<(), anyhow::Error> {
         let num_siblings = left_siblings.len() + self.right_siblings.len();
         let mut left_sibling_iter = left_siblings.iter();
         let mut right_sibling_iter = self.right_siblings().iter();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -16,8 +16,10 @@ use crate::{
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
 /// to the underlying storage holding nodes.
 pub trait TreeWriter {
+    /// The kind of error that may be returned by [`TreeWriter::write_node_batch()`].
+    type Error;
     /// Writes a node batch into storage.
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()>;
+    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<(), Self::Error>;
 }
 
 /// Node batch that will be written into db atomically with other batches.


### PR DESCRIPTION
this updates `jmt` so that its public interface uses concrete, typed error variants rather than boxed `dyn` errors.

#### :construction: todo's

some todo's before i mark this as officially ready for review

- [ ] sort out `no_std` compatibility (consider `snafu`)
- [ ] fix non-default feature flags (_this is causing tests to fail_)
- [ ] add `#[non_exhaustive]` to errors
- [ ] bump `Cargo.toml` package version

while i sort these things out, i may be force-pushing to this branch regularly. you've been warned!

#### :eye: note for reviewers

a pattern that shows up in some places is replacing...

```rust
ensure!(a == b, "an invariant")
```

...with...

```rust
if a != b {
    return Err(SomeError::Kind);
}
```

...we should keep a close eye out for conditionals that are not inverted when this transformation is applied.